### PR TITLE
Add srt and mbedtls support to FFmpeg

### DIFF
--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -198,6 +198,18 @@ Requires.private: mbedcrypto
 EOF
 
 cd $WORK_DIR
+
+# srt
+curl -L -O https://github.com/Haivision/srt/archive/v1.4.1.tar.gz
+tar -xf v1.4.1.tar.gz
+cd srt-1.4.1
+mkdir build
+cd ./build
+cmake -DCMAKE_INSTALL_PREFIX="/tmp/obsdeps" -DENABLE_APPS=OFF -DUSE_ENCLIB="mbedtls" -DENABLE_STATIC=ON -DENABLE_SHARED=OFF  -DSSL_INCLUDE_DIRS="/tmp/obsdeps/include" -DSSL_LIBRARY_DIRS="/tmp/obsdeps/lib" -DCMAKE_FIND_FRAMEWORK=LAST ..
+make -j
+make install
+
+cd $WORK_DIR
 export LDFLAGS="-L/tmp/obsdeps/lib"
 export CFLAGS="-I/tmp/obsdeps/include"
 

--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -212,6 +212,7 @@ make install
 cd $WORK_DIR
 export LDFLAGS="-L/tmp/obsdeps/lib"
 export CFLAGS="-I/tmp/obsdeps/include"
+export LD_LIBRARY_PATH="/tmp/obsdeps/lib"
 
 # FFMPEG
 curl -L -O https://github.com/FFmpeg/FFmpeg/archive/n4.2.2.zip
@@ -219,11 +220,22 @@ unzip ./n4.2.2.zip
 cd ./FFmpeg-n4.2.2
 mkdir build
 cd ./build
-../configure --pkg-config-flags="--static" --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --disable-outdev=sdl
+../configure --pkg-config-flags="--static" --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-outdev=sdl
 make -j
 find . -name \*.dylib -exec cp \{\} $DEPS_DEST/bin/ \;
 rsync -avh --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/
 rsync -avh --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/
+install_name_tool -change libmbedcrypto.3.dylib /tmp/obsdeps/bin/libmbedcrypto.3.dylib $DEPS_DEST/bin/libavfilter.7.dylib
+install_name_tool -change libmbedcrypto.3.dylib /tmp/obsdeps/bin/libmbedcrypto.3.dylib $DEPS_DEST/bin/libavdevice.58.dylib
+install_name_tool -change libmbedcrypto.3.dylib /tmp/obsdeps/bin/libmbedcrypto.3.dylib $DEPS_DEST/bin/libavformat.58.dylib
+install_name_tool -change libmbedx509.0.dylib /tmp/obsdeps/bin/libmbedx509.0.dylib $DEPS_DEST/bin/libavfilter.7.dylib
+install_name_tool -change libmbedx509.0.dylib /tmp/obsdeps/bin/libmbedx509.0.dylib $DEPS_DEST/bin/libavdevice.58.dylib
+install_name_tool -change libmbedx509.0.dylib /tmp/obsdeps/bin/libmbedx509.0.dylib $DEPS_DEST/bin/libavformat.58.dylib
+install_name_tool -change libmbedtls.12.dylib /tmp/obsdeps/bin/libmbedtls.12.dylib $DEPS_DEST/bin/libavfilter.7.dylib
+install_name_tool -change libmbedtls.12.dylib /tmp/obsdeps/bin/libmbedtls.12.dylib $DEPS_DEST/bin/libavdevice.58.dylib
+install_name_tool -change libmbedtls.12.dylib /tmp/obsdeps/bin/libmbedtls.12.dylib $DEPS_DEST/bin/libavformat.58.dylib
+
+cd $WORK_DIR
 
 #luajit
 curl -L -O https://luajit.org/download/LuaJIT-2.0.5.tar.gz


### PR DESCRIPTION
### Description
* Adds srt as a static library for ffmpeg
* Adds mbedtls as a dynamic library for ffmpeg and OBS
* Add code to correct library paths inside `dylibs` to assist OBS' packaging process for macOS

### Motivation and Context
* Brings srt support to OBS 25 on macOS

### How Has This Been Tested?
* Tested on macOS 10.15.4 with packaged as well as unpackaged OBS builds
* SRT output tested with streaming as well as ffmpeg output using local SRT server
* SRT server output tested with `ffplay` to check video stream

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
