### PR TITLE
Add GitHub action for macOS builds

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,0 +1,32 @@
+name: build_macos
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: [macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install Tools
+        if: success()
+        shell: bash
+        run: ./osx-install-tools.sh
+      - name: Build and Package
+        if: success()
+        shell: bash
+        run: ./build-package-deps-osx.sh
+      - name: PublishBuildArtifacts
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: macos-deps
+          path: './osx'


### PR DESCRIPTION
### Description
Adds necessary GitHub action workflow files to replicate functionality of current Azure pipeline.

### Motivation and Context
Remove dependency on external system and keep CI within GitHub.

### How Has This Been Tested?
* Build functionality tested on own fork

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
