### PR TITLE
Change to GPL version of mbedtls release

### DIFF
--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -201,8 +201,8 @@ build_mbedtls() {
     hr "Building mbedtls v${MBEDTLS_VERSION}"
 
     # mbedtls
-    curl -L -O https://tls.mbed.org/download/mbedtls-${MBEDTLS_VERSION}-apache.tgz
-    tar -xf mbedtls-${MBEDTLS_VERSION}-apache.tgz
+    curl -L -O https://tls.mbed.org/download/mbedtls-${MBEDTLS_VERSION}-gpl.tgz
+    tar -xf mbedtls-${MBEDTLS_VERSION}-gpl.tgz
     cd mbedtls-${MBEDTLS_VERSION}
     sed -i '.orig' 's/\/\/\#define MBEDTLS_THREADING_PTHREAD/\#define MBEDTLS_THREADING_PTHREAD/g' include/mbedtls/config.h
     sed -i '.orig' 's/\/\/\#define MBEDTLS_THREADING_C/\#define MBEDTLS_THREADING_C/g' include/mbedtls/config.h


### PR DESCRIPTION
### Description
Change mbedtls source code download to use GPL-licensed version.

### Motivation and Context
Align license use with OBS Studio.

### How Has This Been Tested?
* Successfully compiled locally and on CI

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
