### PR TITLE
Update workflow to use newer upload-artifact action with proper names

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -23,13 +23,17 @@ jobs:
         if: success()
         shell: bash
         run: ./osx-install-tools.sh
+      - name: Get Current Date
+        shell: bash
+        id: get_date
+        run: echo ::set-output name=CURRENT_DATE::$(date +"%Y-%m-%d")
       - name: Build and Package
         if: success()
         shell: bash
         run: ./build-package-deps-osx.sh
       - name: PublishBuildArtifacts
         if: success() && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2-preview
         with:
-          name: macos-deps
-          path: './osx'
+          name: '${{ steps.get_date.outputs.CURRENT_DATE }}'
+          path: ./osx/*.tar.gz


### PR DESCRIPTION
### Description
Uses newer version of upload-artifact action and additional workflow step to properly name generated artifacts.

### Motivation and Context
Fixes an oversight in the original GitHub Actions workflow.

### How Has This Been Tested?
Artifacts are only created on push, so not fully tested.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
