### PR TITLE
Some freetype fixes

### DIFF
--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -354,12 +354,15 @@ build_freetype() {
     FREETYPE_VERSION=${1}
     hr "Building libfreetype v${FREETYPE_VERSION}"
 
+    export CFLAGS="-mmacosx-version-min=10.11"
+
     curl -L -O https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.bz2
     tar -xf freetype-${FREETYPE_VERSION}.tar.bz2
     cd freetype-${FREETYPE_VERSION}
     ./configure --enable-shared --disable-static --prefix="/tmp/obsdeps" --enable-freetype-config --without-harfbuzz
     make PREFIX=/tmp/obsdeps
     make PREFIX=/tmp/obsdeps install
+    unset CFLAGS
     cd $WORK_DIR
 }
 ## END BUILD FUNCS ##

--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -362,6 +362,8 @@ build_freetype() {
     ./configure --enable-shared --disable-static --prefix="/tmp/obsdeps" --enable-freetype-config --without-harfbuzz
     make PREFIX=/tmp/obsdeps
     make PREFIX=/tmp/obsdeps install
+    find /tmp/obsdeps/lib -name libfreetype\*.dylib -exec cp \{\} ${DEPS_DEST}/lib/ \;
+    rsync -avh --include="*/" --include="*.h" --exclude="*" src/* ${DEPS_DEST}/include/
     unset CFLAGS
     cd $WORK_DIR
 }

--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -20,7 +20,7 @@ BUILD_PACKAGES=(
     "srt 1.4.1"
     "ffmpeg 4.2.2"
     "luajit 2.0.5"
-    "freetype 2.9"
+    "freetype 2.10.1"
 )
 
 ## START UTILITIES ##
@@ -362,8 +362,8 @@ build_freetype() {
     ./configure --enable-shared --disable-static --prefix="/tmp/obsdeps" --enable-freetype-config --without-harfbuzz
     make PREFIX=/tmp/obsdeps
     make PREFIX=/tmp/obsdeps install
-    find /tmp/obsdeps/lib -name libfreetype\*.dylib -exec cp \{\} ${DEPS_DEST}/lib/ \;
-    rsync -avh --include="*/" --include="*.h" --exclude="*" src/* ${DEPS_DEST}/include/
+    find /tmp/obsdeps/lib -name libfreetype\*.dylib -exec cp \{\} ${DEPS_DEST}/bin/ \;
+    rsync -avh --include="*/" --include="*.h" --exclude="*" include/* ${DEPS_DEST}/include/
     unset CFLAGS
     cd $WORK_DIR
 }

--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -356,8 +356,8 @@ build_freetype() {
 
     export CFLAGS="-mmacosx-version-min=10.11"
 
-    curl -L -O https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.bz2
-    tar -xf freetype-${FREETYPE_VERSION}.tar.bz2
+    curl -L -O https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz
+    tar -xf freetype-${FREETYPE_VERSION}.tar.gz
     cd freetype-${FREETYPE_VERSION}
     ./configure --enable-shared --disable-static --prefix="/tmp/obsdeps" --enable-freetype-config --without-harfbuzz
     make PREFIX=/tmp/obsdeps


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
