### PR TITLE
Update luajit to 2.1.0-beta3 to fix possible 64-bit issues

### DIFF
--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -19,7 +19,7 @@ BUILD_PACKAGES=(
     "mbedtls 2.16.5"
     "srt 1.4.1"
     "ffmpeg 4.2.2"
-    "luajit 2.0.5"
+    "luajit 2.1.0-beta3"
     "freetype 2.10.1"
 )
 
@@ -330,6 +330,7 @@ build_luajit() {
     cd LuaJIT-${LUAJIT_VERSION}
     make PREFIX=/tmp/obsdeps
     make PREFIX=/tmp/obsdeps install
+    ln -sf luajit-${LUAJIT_VERSION} /tmp/obsdeps/bin/luajit
     find /tmp/obsdeps/lib -name libluajit\*.dylib -exec cp \{\} ${DEPS_DEST}/lib/ \;
     rsync -avh --include="*/" --include="*.h" --exclude="*" src/* ${DEPS_DEST}/include/
     make PREFIX=/tmp/obsdeps uninstall


### PR DESCRIPTION
### Description
Updates luajit to version 2.1.0-beta3 to fix possible issues with 64-bit environments (mainly macOS Catalina). Usage of 2.1.0 under Catalina is also suggested by the developers themselves: https://github.com/LuaJIT/LuaJIT/issues/521

### Motivation and Context
Possibly fixes https://github.com/obsproject/obs-studio/issues/2784

### How Has This Been Tested?
* Dependencies compiled locally
* OBS built with the dependencies
* LUA scripts tested in OBS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
