### PR TITLE
Update macOS minimum targets from 10.11 to 10.13

### DIFF
--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -75,7 +75,7 @@ mkdir ${DEPS_DEST}/include
 mkdir ${DEPS_DEST}/lib
 
 # OSX COMPAT
-export MACOSX_DEPLOYMENT_TARGET=10.11
+export MACOSX_DEPLOYMENT_TARGET=10.13
 
 # If you need an olders SDK and Xcode won't give it to you
 # https://github.com/phracker/MacOSX-SDKs
@@ -163,10 +163,10 @@ build_x264() {
     git checkout ${X264_VERSION}
     mkdir build
     cd ./build
-    ../configure --extra-ldflags="-mmacosx-version-min=10.11" --enable-static --prefix="/tmp/obsdeps"
+    ../configure --extra-ldflags="-mmacosx-version-min=10.13" --enable-static --prefix="/tmp/obsdeps"
     make -j
     make install
-    ../configure --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --libdir="/tmp/obsdeps/bin" --prefix="/tmp/obsdeps"
+    ../configure --extra-ldflags="-mmacosx-version-min=10.13" --enable-shared --libdir="/tmp/obsdeps/bin" --prefix="/tmp/obsdeps"
     make -j
     ln -f -s libx264.*.dylib libx264.dylib
     find . -name \*.dylib -exec cp \{\} ${DEPS_DEST}/bin/ \;
@@ -299,7 +299,7 @@ build_ffmpeg() {
     cd ./FFmpeg-n${FFMPEG_VERSION}
     mkdir build
     cd ./build
-    ../configure --pkg-config-flags="--static" --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-outdev=sdl
+    ../configure --pkg-config-flags="--static" --extra-ldflags="-mmacosx-version-min=10.13" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-outdev=sdl
     make -j
     find . -name \*.dylib -exec cp \{\} ${DEPS_DEST}/bin/ \;
     rsync -avh --include="*/" --include="*.h" --exclude="*" ../* ${DEPS_DEST}/include/
@@ -355,7 +355,7 @@ build_freetype() {
     FREETYPE_VERSION=${1}
     hr "Building libfreetype v${FREETYPE_VERSION}"
 
-    export CFLAGS="-mmacosx-version-min=10.11"
+    export CFLAGS="-mmacosx-version-min=10.13"
 
     curl -L -O https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz
     tar -xf freetype-${FREETYPE_VERSION}.tar.gz


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Update the minimum macOS build targets from 10.11 to 10.13.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
OBS officially only supports 10.13+ because Qt 5.14.x only supports 10.13+.  Let's just make sure everything is targeting that minimum so that we (hopefully) get the benefits of targeting a newer minimum.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I haven't tested this because I don't have access to a Mac.  We should test against deps built this way, but this shouldn't really change anything.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
