### PR TITLE
Change libogg download from git.xiph.org to gitlab.xiph.org

### DIFF
--- a/build-package-deps-osx.sh
+++ b/build-package-deps-osx.sh
@@ -11,7 +11,7 @@ set -eE
 BUILD_PACKAGES=(
     "libpng 1.6.37"
     "opus 1.3.1"
-    "ogg 68ca384"
+    "ogg 68ca3841567247ac1f7850801a164f58738d8df9"
     "vorbis 1.3.6"
     "vpx 1.8.2"
     "jansson 2.12"
@@ -106,7 +106,7 @@ build_ogg() {
     hr "Building libogg v${OGG_VERSION}"
 
     # libogg
-    curl -L -o ogg-${OGG_VERSION}.tar.gz 'https://git.xiph.org/?p=ogg.git;a=snapshot;h=68ca3841567247ac1f7850801a164f58738d8df9;sf=tgz'
+    curl -L -o ogg-${OGG_VERSION}.tar.gz https://gitlab.xiph.org/xiph/ogg/-/archive/${OGG_VERSION}/ogg-${OGG_VERSION}.tar.gz
     tar -xf ogg-${OGG_VERSION}.tar.gz
     cd ./ogg-${OGG_VERSION}
     mkdir build


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Xiph has migrated a few of their repositories to GitLab recently and git.xiph.org seems to have been down for a while. Let's change this download to their GitLab instance so it stops failing.

Unfortunately, because of how GitLab packages the download and refers to the commit, I had to pass the full commit hash in BUILD_PACKAGES instead of the short hash.

https://gitlab.xiph.org/xiph/opus/-/merge_requests/2

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
CI failing is sad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I let this run on my Azure Pipeline to make sure that it builds.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
