### PR TITLE
CI: Fix Qt building imageformats plugin with Homebrew-provided deps

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install Homebrew dependencies
         shell: bash
         run: |
+          brew update --preinstall
           brew bundle
       - name: Get Current Date
         shell: bash
@@ -499,6 +500,7 @@ jobs:
       - name: Install Homebrew dependencies
         shell: bash
         run: |
+          brew update --preinstall
           brew bundle
       - name: Get Current Date
         shell: bash
@@ -516,7 +518,7 @@ jobs:
         id: qt-cache
         uses: actions/cache@v2
         env:
-          CACHE_NAME: 'qt-build-cache'
+          CACHE_NAME: 'qt-build-cache-rev3'
         with:
           path: /tmp/obsdeps
           key: ${{ runner.os }}-deps-${{ env.CACHE_NAME }}-${{ env.MAC_QT_VERSION }}
@@ -527,6 +529,14 @@ jobs:
         run: |
           if [ -d /usr/local/opt/zstd ]; then
             brew unlink zstd
+          fi
+
+          if [ -d /usr/local/opt/libtiff ]; then
+            brew unlink libtiff
+          fi
+
+          if [ -d /usr/local/opt/webp ]; then
+            brew unlink webp
           fi
 
           curl --retry 5 -L -C - -O "https://download.qt.io/official_releases/qt/$(echo "${{ env.MAC_QT_VERSION }}" | cut -d "." -f -2)/${{ env.MAC_QT_VERSION }}/single/qt-everywhere-src-${{ env.MAC_QT_VERSION }}.tar.xz"

--- a/build_script_generator.py
+++ b/build_script_generator.py
@@ -42,7 +42,8 @@ def parse_macos_job(job_data, template, step_template, global_env):
     find_setenv_pattern = re.compile('echo ::set-env name=(.+?)::(.+)')
     find_env_pattern = re.compile('\\${{ env.(.+?) }}')
     find_heredoc_pattern = re.compile('<<(.+?) (.+?)?\n(.+?)\\1', re.MULTILINE|re.DOTALL)
-    current_path = os.path.realpath('.')
+    # current_path = os.path.realpath('.')
+    current_path = "${BASE_DIR}"
     environment = global_env
     environment.update(job_data.get('env', {}))
     environment.update(PATH="/usr/local/opt/ccache/libexec:${PATH}")

--- a/osx-install-tools.sh
+++ b/osx-install-tools.sh
@@ -1,1 +1,2 @@
+brew update --preinstall
 brew bundle

--- a/templates/build-script-macos.tpl
+++ b/templates/build-script-macos.tpl
@@ -3,6 +3,7 @@
 set -eE
 
 PRODUCT_NAME="OBS Pre-Built Dependencies"
+BASE_DIR="$(git rev-parse --show-toplevel)"
 
 COLOR_RED=$(tput setaf 1)
 COLOR_GREEN=$(tput setaf 2)

--- a/templates/build-script-ubuntu.tpl
+++ b/templates/build-script-ubuntu.tpl
@@ -3,6 +3,7 @@
 set -eE
 
 PRODUCT_NAME="OBS Pre-Built Dependencies"
+BASE_DIR="$(git rev-parse --show-toplevel)"
 
 COLOR_RED=$(tput setaf 1)
 COLOR_GREEN=$(tput setaf 2)


### PR DESCRIPTION
### Description
Hides `webp` and `libtiff` from Qt by unlinking them if installed via Homebrew, forcing Qt to use self-provided third party source code to compile both dependencies statically into its frameworks.

_Bonus Level:_ The provided build script generator was committing unusable scripts back into the repository, as an absolute checkout folder was used for script generation. The PR changes this to use the dynamically detected git checkout directory instead.

### Motivation and Context
Qt requires the `imageformats` plugin by default, which itself has dynamic libraries for tiff and webp support. If neither library is available on the system, their respective libraries are compiled into the Qt plugin library with the source code Qt provides themselves.

On CI and some local machines both these libraries might exist already (e.g. through another package that required them) and Qt will happily use those instead of the ones contained in its source repository. This leads to the unfortunate situation that the Qt libraries we ship as part of obs-deps might require these Homebrew libraries to exist on the local machine to work.

### How Has This Been Tested?
- Qt built locally with these changes, checked all plugin libraries for any other libraries linked from `/usr/local`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
