### PR TITLE
Build windows deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,3 +17,45 @@ jobs:
     inputs:
       pathtoPublish: './osx'
       artifactName: osx-deps
+
+- job: 'Build_Win32'
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - script: ./win-install-tools.sh
+    displayName: 'Install Tools'
+  - script: ./win32.sh
+    displayName: 'Build deps'
+
+  - task: PublishBuildArtifacts@1
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    inputs:
+      pathtoPublish: './ffmpeg/ffbuild'
+      artifactName: ffmpeglogs
+
+  - task: PublishBuildArtifacts@1
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    inputs:
+      pathtoPublish: './win32'
+      artifactName: win32-deps
+
+- job: 'Build_Win64'
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - script: ./win-install-tools.sh
+    displayName: 'Install Tools'
+  - script: ./win64.sh
+    displayName: 'Build deps'
+
+  - task: PublishBuildArtifacts@1
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    inputs:
+      pathtoPublish: './ffmpeg/ffbuild'
+      artifactName: ffmpeglogs
+
+  - task: PublishBuildArtifacts@1
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    inputs:
+      pathtoPublish: './win64'
+      artifactName: win64-deps

--- a/patch/ffmpeg/ffmpeg_flvdec.patch
+++ b/patch/ffmpeg/ffmpeg_flvdec.patch
@@ -1,0 +1,13 @@
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index b531a39adc..6b0a104f18 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1056,7 +1056,7 @@ retry:
+             int type;
+             meta_pos = avio_tell(s->pb);
+             type = flv_read_metabody(s, next);
+-            if (type == 0 && dts == 0 || type < 0) {
++            if (type == 0 && dts == 0 || type < 0 || type == TYPE_UNKNOWN) {
+                 if (type < 0 && flv->validate_count &&
+                     flv->validate_index[0].pos     > next &&
+                     flv->validate_index[0].pos - 4 < next

--- a/patch/libvpx/libvpx-crosscompile-win-dll.patch
+++ b/patch/libvpx/libvpx-crosscompile-win-dll.patch
@@ -1,0 +1,187 @@
+diff --git a/build/make/Makefile b/build/make/Makefile
+index c070cd0..ba5844d 100644
+--- a/build/make/Makefile
++++ b/build/make/Makefile
+@@ -308,6 +308,19 @@ $(1):
+             $$(filter %.o,$$^) $$(extralibs)
+ endef
+ 
++define dll_gnu_template
++# Not using a pattern rule here because we don't want to generate empty
++# archives when they are listed as a dependency in files not responsible
++# for creating them.
++#
++# This needs further abstraction for dealing with non-GNU linkers.
++$(1):
++	$(if $(quiet),@echo "    [LD] $$@")
++	$(qexec)$$(LD) -shared $$(LDFLAGS) \
++            -Wl,--no-undefined -o $$@ \
++            -Wl,--out-implib=$$(subst $(2),.dll.a,$(1)) $$(filter %.o,$$^) $$(extralibs)
++endef
++
+ define dl_template
+ # Not using a pattern rule here because we don't want to generate empty
+ # archives when they are listed as a dependency in files not responsible
+@@ -391,6 +404,7 @@ $(foreach lib,$(filter %_g.a,$(LIBS)),$(eval $(call archive_template,$(lib))))
+ $(foreach lib,$(filter %so.$(SO_VERSION_MAJOR).$(SO_VERSION_MINOR).$(SO_VERSION_PATCH),$(LIBS)),$(eval $(call so_template,$(lib))))
+ $(foreach lib,$(filter %$(SO_VERSION_MAJOR).dylib,$(LIBS)),$(eval $(call dl_template,$(lib))))
+ $(foreach lib,$(filter %$(SO_VERSION_MAJOR).dll,$(LIBS)),$(eval $(call dll_template,$(lib))))
++$(foreach lib,$(filter %-$(VERSION_MAJOR).dll,$(LIBS)),$(eval $(call dll_gnu_template,$(lib),-$(VERSION_MAJOR).dll)))
+ 
+ INSTALL-LIBS=$(call cond_enabled,CONFIG_INSTALL_LIBS,INSTALL-LIBS)
+ ifeq ($(MAKECMDGOALS),dist)
+diff --git a/build/make/configure.sh b/build/make/configure.sh
+index 472e7de..3dc602f 100644
+--- a/build/make/configure.sh
++++ b/build/make/configure.sh
+@@ -647,7 +647,14 @@ process_common_cmdline() {
+       --libdir=*)
+         libdir="${optval}"
+         ;;
+-      --libc|--as|--prefix|--libdir)
++      --bindir=*)
++        bindir="${optval}"
++        ;;
++      --sdk-path=*)
++        [ -d "${optval}" ] || die "Not a directory: ${optval}"
++        sdk_path="${optval}"
++        ;;
++      --libc|--as|--prefix|--libdir|--bindir|--sdk-path)
+         die "Option ${opt} requires argument"
+         ;;
+       --help|-h)
+@@ -676,9 +683,14 @@ post_process_common_cmdline() {
+   prefix="${prefix%/}"
+   libdir="${libdir:-${prefix}/lib}"
+   libdir="${libdir%/}"
++  bindir="${bindir:-${prefix}/bin}"
++  bindir="${bindir%/}"
+   if [ "${libdir#${prefix}}" = "${libdir}" ]; then
+     die "Libdir ${libdir} must be a subdirectory of ${prefix}"
+   fi
++  if [ "${bindir#${prefix}}" = "${bindir}" ]; then
++    die "Bindir ${bindir} must be a subdirectory of ${prefix}"
++  fi
+ }
+ 
+ post_process_cmdline() {
+diff --git a/configure b/configure
+index d29e00a..379a2e3 100755
+--- a/configure
++++ b/configure
+@@ -494,6 +494,7 @@ else
+ DIST_DIR?=\$(DESTDIR)${prefix}
+ endif
+ LIBSUBDIR=${libdir##${prefix}/}
++BINSUBDIR=${bindir##${prefix}/}
+ 
+ VERSION_STRING=${VERSION_STRING}
+ 
+@@ -531,9 +532,13 @@ process_detect() {
+             ;;
+         *)
+             if enabled gnu; then
+-                echo "--enable-shared is only supported on ELF; assuming this is OK"
++                echo "--enable-shared is only supported on ELF/PE; assuming this is OK"
++            elif enabled win32; then
++                echo "--enable-shared is only supported on ELF/PE; assuming this is OK"
++            elif enabled win64; then
++                echo "--enable-shared is only supported on ELF/PE; assuming this is OK"
+             else
+-                die "--enable-shared only supported on ELF, OS/2, and Darwin for now"
++                die "--enable-shared only supported on ELF, PE, OS/2, Darwin, win32, and win64 for now."
+             fi
+             ;;
+         esac
+diff --git a/examples.mk b/examples.mk
+index 758ca7f..23f8690 100644
+--- a/examples.mk
++++ b/examples.mk
+@@ -328,10 +328,13 @@ SHARED_LIB_SUF=.dylib
+ else
+ ifneq ($(filter os2%,$(TGT_OS)),)
+ SHARED_LIB_SUF=_dll.a
++ifneq ($(filter win%,$(TGT_OS)),)
++SHARED_LIB_SUF=.dll.a
+ else
+ SHARED_LIB_SUF=.so
+ endif
+ endif
++endif
+ CODEC_LIB_SUF=$(if $(CONFIG_SHARED),$(SHARED_LIB_SUF),.a)
+ $(foreach bin,$(BINS-yes),\
+     $(eval $(bin):$(LIB_PATH)/lib$(CODEC_LIB)$(CODEC_LIB_SUF))\
+diff --git a/libs.mk b/libs.mk
+index 67d7512..05aa0d7 100644
+--- a/libs.mk
++++ b/libs.mk
+@@ -125,6 +125,7 @@ endif
+ INSTALL_MAPS += include/vpx/% $(SRC_PATH_BARE)/vpx/%
+ INSTALL_MAPS += include/vpx/% $(SRC_PATH_BARE)/vpx_ports/%
+ INSTALL_MAPS += $(LIBSUBDIR)/%     %
++INSTALL_MAPS += $(BINSUBDIR)/%     %
+ INSTALL_MAPS += src/%     $(SRC_PATH_BARE)/%
+ ifeq ($(CONFIG_MSVS),yes)
+ INSTALL_MAPS += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/%  $(p)/Release/%)
+@@ -255,6 +256,13 @@ EXPORT_FILE             := libvpx.def
+ LIBVPX_SO_SYMLINKS      :=
+ LIBVPX_SO_IMPLIB        := libvpx_dll.a
+ else
++ifeq ($(filter win%,$(TGT_OS)),$(TGT_OS))
++LIBVPX_SO               := libvpx-$(VERSION_MAJOR).dll
++SHARED_LIB_SUF          := .dll.a
++EXPORT_FILE             := libvpx.def
++LIBVPX_SO_SYMLINKS      :=
++LIBVPX_SO_IMPLIB        := libvpx.dll.a
++else
+ LIBVPX_SO               := libvpx.so.$(SO_VERSION_MAJOR).$(SO_VERSION_MINOR).$(SO_VERSION_PATCH)
+ SHARED_LIB_SUF          := .so
+ EXPORT_FILE             := libvpx.ver
+@@ -264,13 +272,14 @@ LIBVPX_SO_SYMLINKS      := $(addprefix $(LIBSUBDIR)/, \
+ endif
+ endif
+ endif
++endif
+ 
+ LIBS-$(CONFIG_SHARED) += $(BUILD_PFX)$(LIBVPX_SO)\
+                            $(notdir $(LIBVPX_SO_SYMLINKS)) \
+                            $(if $(LIBVPX_SO_IMPLIB), $(BUILD_PFX)$(LIBVPX_SO_IMPLIB))
+ $(BUILD_PFX)$(LIBVPX_SO): $(LIBVPX_OBJS) $(EXPORT_FILE)
+ $(BUILD_PFX)$(LIBVPX_SO): extralibs += -lm
+-$(BUILD_PFX)$(LIBVPX_SO): SONAME = libvpx.so.$(SO_VERSION_MAJOR)
++$(BUILD_PFX)$(LIBVPX_SO): SONAME = $(LIBVPX_SO)
+ $(BUILD_PFX)$(LIBVPX_SO): EXPORTS_FILE = $(EXPORT_FILE)
+ 
+ libvpx.def: $(call enabled,CODEC_EXPORTS)
+@@ -286,6 +295,10 @@ libvpx_dll.a: $(LIBVPX_SO)
+ 	$(qexec)emximp -o $@ $<
+ CLEAN-OBJS += libvpx_dll.a
+ 
++libvpx.dll.a: $(LIBVPX_SO)
++	@echo "    [IMPLIB] $@"
++CLEAN-OBJS += libvpx.dll.a
++
+ define libvpx_symlink_template
+ $(1): $(2)
+ 	@echo "    [LN]     $(2) $$@"
+@@ -302,7 +315,7 @@ $(eval $(call libvpx_symlink_template,\
+ 
+ 
+ INSTALL-LIBS-$(CONFIG_SHARED) += $(LIBVPX_SO_SYMLINKS)
+-INSTALL-LIBS-$(CONFIG_SHARED) += $(LIBSUBDIR)/$(LIBVPX_SO)
++INSTALL-LIBS-$(CONFIG_SHARED) += $(BINSUBDIR)/$(LIBVPX_SO)
+ INSTALL-LIBS-$(CONFIG_SHARED) += $(if $(LIBVPX_SO_IMPLIB),$(LIBSUBDIR)/$(LIBVPX_SO_IMPLIB))
+ 
+ 
+diff --git a/vp8/common/threading.h b/vp8/common/threading.h
+index 58b9013..fe39726 100644
+--- a/vp8/common/threading.h
++++ b/vp8/common/threading.h
+@@ -73,6 +73,7 @@ extern "C" {
+ #include <unistd.h>
+ 
+ #else
++#include <sys/stat.h>
+ #include <semaphore.h>
+ #endif
+ 

--- a/patch/mbedtls/threading_alt.h
+++ b/patch/mbedtls/threading_alt.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef void *mbedtls_threading_mutex_t;

--- a/patch/zlib/zlib-disable-shared-lib-prefix.patch
+++ b/patch/zlib/zlib-disable-shared-lib-prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0fe939d..67254b3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,8 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
+ 
+ project(zlib C)
+ 
++set(CMAKE_SHARED_LIBRARY_PREFIX "")
++
+ set(VERSION "1.2.11")
+ 
+ option(ASM686 "Enable building i686 assembly implementation")

--- a/patch/zlib/zlib-include-zconf.patch
+++ b/patch/zlib/zlib-include-zconf.patch
@@ -1,0 +1,13 @@
+diff --git a/include/zconf.h b/include/zconf.h
+index 995ad4f..a5e3452 100644
+--- a/include/zconf.h
++++ b/include/zconf.h
+@@ -474,7 +474,7 @@ typedef uLong FAR uLongf;
+ #endif
+ #ifndef Z_SOLO
+ #  if defined(Z_HAVE_UNISTD_H) || defined(_LARGEFILE64_SOURCE)
+-#    include <unistd.h>         /* for SEEK_*, off_t, and _LFS64_LARGEFILE */
++//#    include <unistd.h>         /* for SEEK_*, off_t, and _LFS64_LARGEFILE */
+ #    ifdef VMS
+ #      include <unixio.h>       /* for off_t */
+ #    endif

--- a/win-install-tools.sh
+++ b/win-install-tools.sh
@@ -1,0 +1,12 @@
+#/bin/bash
+
+sudo apt install automake cmake curl git libtool mingw-w64 mingw-w64-tools \
+	pkg-config wget
+
+curl -L -O http://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz
+tar -xf nasm-2.14.02.tar.xz
+cd ./nasm-2.14.02
+./configure
+make
+sudo make install
+

--- a/win32.sh
+++ b/win32.sh
@@ -169,8 +169,15 @@ cd ..
 #---------------------------------
 
 
+# opus
 #read -n1 -r -p "Press any key to build opus..." key
 
+# download opus
+curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.3.1.tar.gz
+tar -xf opus-1.3.1.tar.gz
+mv opus-1.3.1 opus
+
+# build opus
 cd opus
 make clean
 LDFLAGS="-static-libgcc" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared

--- a/win32.sh
+++ b/win32.sh
@@ -1,5 +1,6 @@
 #/bin/bash
 
+# make directories
 rm -rf win32
 mkdir win32
 cd win32
@@ -7,6 +8,7 @@ mkdir bin
 mkdir include
 mkdir lib
 cd ..
+mkdir -p win32/lib/pkgconfig
 
 read -n1 -r -p "Press any key to build mbedtls.." key
 
@@ -32,7 +34,6 @@ make install
 cd ../..
 
 mv win32/lib/*.dll win32/bin
-mkdir win32/lib/pkgconfig
 
 #---------------------------------
 

--- a/win32.sh
+++ b/win32.sh
@@ -223,8 +223,15 @@ cd $WORKDIR
 #---------------------------------
 
 
+# libpng
 #read -n1 -r -p "Press any key to build libpng..." key
 
+# download libpng
+curl --retry 5 -L -o libpng-1.6.37.tar.gz https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
+tar -xf libpng-1.6.37.tar.gz
+mv libpng-1.6.37 libpng
+
+# build libpng
 cd libpng
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared

--- a/win32.sh
+++ b/win32.sh
@@ -105,8 +105,15 @@ EOF
 #---------------------------------
 
 
+# pthread-win32
 read -n1 -r -p "Press any key to build pthread-win32..." key
 
+# download pthread-win32
+curl --retry 5 -L -o pthread-win32-master.zip https://github.com/GerHobbelt/pthread-win32/archive/master.zip
+unzip pthread-win32-master.zip
+mv pthread-win32-master pthread-win32
+
+# build pthread-win32
 cd pthread-win32
 make DESTROOT=$PREFIX CROSS=i686-w64-mingw32- realclean GC-small-static
 cp libpthreadGC2.a $PREFIX/lib

--- a/win32.sh
+++ b/win32.sh
@@ -266,8 +266,15 @@ cd ../..
 #---------------------------------
 
 
+# libvorbis
 #read -n1 -r -p "Press any key to build libvorbis..." key
 
+# download libvorbis
+curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.6.tar.gz
+tar -xf libvorbis-1.3.6.tar.gz
+mv libvorbis-1.3.6 libvorbis
+
+# build libvorbis
 cd libvorbis
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared --with-ogg="$PREFIX"

--- a/win32.sh
+++ b/win32.sh
@@ -1,0 +1,198 @@
+#/bin/bash
+
+rm -rf win32
+mkdir win32
+cd win32
+mkdir bin
+mkdir include
+mkdir lib
+cd ..
+
+read -n1 -r -p "Press any key to build mbedtls.." key
+
+mkdir mbedtlsbuild
+mkdir mbedtlsbuild/win32
+cd mbedtlsbuild/win32
+rm -rf *
+cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
+make -j6
+i686-w64-mingw32-dlltool -z mbedtls.orig.def --export-all-symbols library/libmbedtls.dll
+i686-w64-mingw32-dlltool -z mbedcrypto.orig.def --export-all-symbols library/libmbedcrypto.dll
+i686-w64-mingw32-dlltool -z mbedx509.orig.def --export-all-symbols library/libmbedx509.dll
+grep "EXPORTS\|mbedtls" mbedtls.orig.def > mbedtls.def
+grep "EXPORTS\|mbedtls" mbedcrypto.orig.def > mbedcrypto.def
+grep "EXPORTS\|mbedtls" mbedx509.orig.def > mbedx509.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedtls.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedcrypto.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedx509.def
+i686-w64-mingw32-dlltool -m i386 -d mbedtls.def -l /home/jim/packages/win32/bin/mbedtls.lib -D library/libmbedtls.dll
+i686-w64-mingw32-dlltool -m i386 -d mbedcrypto.def -l /home/jim/packages/win32/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
+i686-w64-mingw32-dlltool -m i386 -d mbedx509.def -l /home/jim/packages/win32/bin/mbedx509.lib -D library/libmbedx509.dll
+make install
+cd ../..
+
+mv win32/lib/*.dll win32/bin
+mkdir win32/lib/pkgconfig
+
+#---------------------------------
+
+cat > win32/lib/pkgconfig/mbedtls.pc <<EOF
+prefix=/home/jim/packages/win32
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: mbedtls
+Description:
+Version: 1.0.0
+Requires:
+Conflicts:
+Libs: -L\${libdir} -lmbedtls
+Cflags: -I\${includedir} -I\${includedir}/mbedtls
+EOF
+
+#---------------------------------
+
+cat > win32/lib/pkgconfig/mbedcrypto.pc <<EOF
+prefix=/home/jim/packages/win32
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: mbedcrypto
+Description:
+Version: 1.0.0
+Requires:
+Conflicts:
+Libs: -L\${libdir} -lmbedcrypto
+Cflags: -I\${includedir} -I\${includedir}/mbedtls
+EOF
+
+#---------------------------------
+
+cat > win32/lib/pkgconfig/mbedx509.pc <<EOF
+prefix=/home/jim/packages/win32
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: mbedx509
+Description:
+Version: 1.0.0
+Requires:
+Conflicts:
+Libs: -L\${libdir} -lmbedx509
+Cflags: -I\${includedir} -I\${includedir}/mbedtls
+EOF
+
+#---------------------------------
+
+read -n1 -r -p "Press any key to build pthread-win32.." key
+
+cd pthread-win32
+make DESTROOT=/home/jim/packages/win32 CROSS=i686-w64-mingw32- realclean GC-small-static
+cp libpthreadGC2.a /home/jim/packages/win32/lib
+cd ..
+
+read -n1 -r -p "Press any key to build libsrt.." key
+
+mkdir srtbuild
+mkdir srtbuild/win32
+cd srtbuild/win32
+rm -rf *
+cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_CXX_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="/home/jim/packages/win32/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="/home/jim/packages/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
+make -j6
+i686-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
+make install
+cd ../..
+
+read -n1 -r -p "Press any key to build x264..." key
+
+cd x264
+make clean
+LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=i686-w64-mingw32- --host=i686-pc-mingw32 --prefix="/home/jim/packages/win32"
+make -j6
+make install
+i686-w64-mingw32-dlltool -z /home/jim/packages/win32/bin/x264.orig.def --export-all-symbols /home/jim/packages/win32/bin/libx264-157.dll
+grep "EXPORTS\|x264" /home/jim/packages/win32/bin/x264.orig.def > /home/jim/packages/win32/bin/x264.def
+rm -f /home/jim/packages/win32/bin/x264.org.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" /home/jim/packages/win32/bin/x264.def
+i686-w64-mingw32-dlltool -m i386 -d /home/jim/packages/win32/bin/x264.def -l /home/jim/packages/win32/bin/x264.lib -D /home/jim/win32/packages/bin/libx264-157.dll
+cd ..
+
+#read -n1 -r -p "Press any key to build opus..." key
+
+cd opus
+make clean
+LDFLAGS="-static-libgcc" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build zlib..." key
+
+cd zlib/build32
+make clean
+cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DINSTALL_PKGCONFIG_DIR=/home/jim/packages/win32/lib/pkgconfig -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
+make -j6
+make install
+mv ../../win32/lib/libzlib.dll.a ../../win32/lib/libz.dll.a
+mv ../../win32/lib/libzlibstatic.a ../../win32/lib/libz.a
+cp ../win32/zlib.def /home/jim/packages/win32/bin
+i686-w64-mingw32-dlltool -m i386 -d ../win32/zlib.def -l /home/jim/packages/win32/bin/zlib.lib -D /home/jim/win32/packages/bin/zlib.dll
+cd ../..
+
+#read -n1 -r -p "Press any key to build libpng..." key
+
+cd libpng
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build libogg..." key
+
+cd libogg
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build libvorbis..." key
+
+cd libvorbis
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared --with-ogg="/home/jim/packages/win32"
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build libvpx..." key
+
+cd libvpxbuild
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" CROSS=i686-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=/home/jim/packages/win32 --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86-win32-gcc
+make -j6
+make install
+i686-w64-mingw32-dlltool -m i386 -d libvpx.def -l /home/jim/packages/win32/bin/vpx.lib -D /home/jim/win32/packages/bin/libvpx-1.dll
+cd ..
+
+read -n1 -r -p "Press any key to build FFmpeg..." key
+
+cd nv-codec-headers
+make PREFIX="/home/jim/packages/win32"
+make PREFIX="/home/jim/packages/win32" install
+cd ..
+
+mkdir win32/include/AMF
+cp -a AMF/amf/public/include/* /home/jim/packages/win32/include/AMF
+
+cd ffmpeg
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CFLAGS="-I/home/jim/packages/win32/include -I/home/jim/packages/pthread-win32" ./configure --enable-gpl --disable-programs --disable-doc --arch=x86 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=i686-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="/home/jim/packages/win32" --disable-postproc
+read -n1 -r -p "Press any key to continue building FFmpeg..." key
+make -j6
+make install
+cd ..

--- a/win32.sh
+++ b/win32.sh
@@ -313,17 +313,33 @@ pkg-config --libs vpx
 #---------------------------------
 
 
+# FFmpeg
 read -n1 -r -p "Press any key to build FFmpeg..." key
 
+# nv-codec-headers
+# download nv-codec-headers
+git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
 cd nv-codec-headers
-make PREFIX="$PREFIX"
-make PREFIX="$PREFIX" install
+
+# build nv-codec-headers
+make PREFIX=$PREFIX
+make PREFIX=$PREFIX install
 cd ..
 
-mkdir $PREFIX/include/AMF
-cp -a AMF/amf/public/include/* $PREFIX/include/AMF
+# AMF
+# download/prep AMF
+git clone https://github.com/obsproject/obs-amd-encoder.git
+mkdir -p $PREFIX/include/AMF
+cp -a obs-amd-encoder/AMF/amf/public/include/* $PREFIX/include/AMF
 
+# download FFmpeg
+curl -L -o FFmpeg-n4.2.2.zip https://github.com/FFmpeg/FFmpeg/archive/n4.2.2.zip
+unzip FFmpeg-n4.2.2.zip
+mv FFmpeg-n4.2.2 ffmpeg
+
+# build FFmpeg
 cd ffmpeg
+patch -p1 < ../patch/ffmpeg/ffmpeg_flvdec.patch
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CFLAGS="-I$PREFIX/include -I$WORKDIR/pthread-win32" ./configure --enable-gpl --disable-programs --disable-doc --arch=x86 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=i686-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="$PREFIX" --disable-postproc
 read -n1 -r -p "Press any key to continue building FFmpeg..." key

--- a/win32.sh
+++ b/win32.sh
@@ -144,18 +144,25 @@ cd ../..
 #---------------------------------
 
 
+# x264
 read -n1 -r -p "Press any key to build x264..." key
 
+# download and prep x264
+git clone https://code.videolan.org/videolan/x264.git
 cd x264
+git checkout 72db437770fd1ce3961f624dd57a8e75ff65ae0b
+
+# build x264
+x264_api="$(grep '#define X264_BUILD' < x264.h | sed 's/^.* \([1-9][0-9]*\).*$/\1/')"
 make clean
 LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=i686-w64-mingw32- --host=i686-pc-mingw32 --prefix="$PREFIX"
 make -j$(nproc)
 make install
-i686-w64-mingw32-dlltool -z $PREFIX/bin/x264.orig.def --export-all-symbols $PREFIX/bin/libx264-157.dll
+i686-w64-mingw32-dlltool -z $PREFIX/bin/x264.orig.def --export-all-symbols $PREFIX/bin/libx264-$x264_api.dll
 grep "EXPORTS\|x264" $PREFIX/bin/x264.orig.def > $PREFIX/bin/x264.def
-rm -f $PREFIX/bin/x264.org.def
+rm -f $PREFIX/bin/x264.orig.def
 sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" $PREFIX/bin/x264.def
-i686-w64-mingw32-dlltool -m i386 -d $PREFIX/bin/x264.def -l $PREFIX/bin/x264.lib -D $PREFIX/bin/libx264-157.dll
+i686-w64-mingw32-dlltool -m i386 -d $PREFIX/bin/x264.def -l $PREFIX/bin/x264.lib -D $PREFIX/bin/libx264-$x264_api.dll
 cd ..
 
 

--- a/win32.sh
+++ b/win32.sh
@@ -10,6 +10,10 @@ mkdir lib
 cd ..
 mkdir -p win32/lib/pkgconfig
 
+
+#---------------------------------
+
+
 read -n1 -r -p "Press any key to build mbedtls..." key
 
 mkdir mbedtlsbuild
@@ -35,8 +39,6 @@ cd ../..
 
 mv win32/lib/*.dll win32/bin
 
-#---------------------------------
-
 cat > win32/lib/pkgconfig/mbedtls.pc <<EOF
 prefix=/home/jim/packages/win32
 exec_prefix=\${prefix}
@@ -51,8 +53,6 @@ Conflicts:
 Libs: -L\${libdir} -lmbedtls
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
-
-#---------------------------------
 
 cat > win32/lib/pkgconfig/mbedcrypto.pc <<EOF
 prefix=/home/jim/packages/win32
@@ -69,8 +69,6 @@ Libs: -L\${libdir} -lmbedcrypto
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
-#---------------------------------
-
 cat > win32/lib/pkgconfig/mbedx509.pc <<EOF
 prefix=/home/jim/packages/win32
 exec_prefix=\${prefix}
@@ -86,7 +84,9 @@ Libs: -L\${libdir} -lmbedx509
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
+
 #---------------------------------
+
 
 read -n1 -r -p "Press any key to build pthread-win32..." key
 
@@ -94,6 +94,10 @@ cd pthread-win32
 make DESTROOT=/home/jim/packages/win32 CROSS=i686-w64-mingw32- realclean GC-small-static
 cp libpthreadGC2.a /home/jim/packages/win32/lib
 cd ..
+
+
+#---------------------------------
+
 
 read -n1 -r -p "Press any key to build libsrt..." key
 
@@ -106,6 +110,10 @@ make -j$(nproc)
 i686-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
 cd ../..
+
+
+#---------------------------------
+
 
 read -n1 -r -p "Press any key to build x264..." key
 
@@ -121,6 +129,10 @@ sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" /home/jim/packages/win32
 i686-w64-mingw32-dlltool -m i386 -d /home/jim/packages/win32/bin/x264.def -l /home/jim/packages/win32/bin/x264.lib -D /home/jim/win32/packages/bin/libx264-157.dll
 cd ..
 
+
+#---------------------------------
+
+
 #read -n1 -r -p "Press any key to build opus..." key
 
 cd opus
@@ -129,6 +141,10 @@ LDFLAGS="-static-libgcc" ./configure --host=i686-w64-mingw32 --prefix="/home/jim
 make -j$(nproc)
 make install
 cd ..
+
+
+#---------------------------------
+
 
 #read -n1 -r -p "Press any key to build zlib..." key
 
@@ -143,6 +159,10 @@ cp ../win32/zlib.def /home/jim/packages/win32/bin
 i686-w64-mingw32-dlltool -m i386 -d ../win32/zlib.def -l /home/jim/packages/win32/bin/zlib.lib -D /home/jim/win32/packages/bin/zlib.dll
 cd ../..
 
+
+#---------------------------------
+
+
 #read -n1 -r -p "Press any key to build libpng..." key
 
 cd libpng
@@ -151,6 +171,10 @@ PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/pa
 make -j$(nproc)
 make install
 cd ..
+
+
+#---------------------------------
+
 
 #read -n1 -r -p "Press any key to build libogg..." key
 
@@ -161,6 +185,10 @@ make -j$(nproc)
 make install
 cd ..
 
+
+#---------------------------------
+
+
 #read -n1 -r -p "Press any key to build libvorbis..." key
 
 cd libvorbis
@@ -169,6 +197,10 @@ PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/pa
 make -j$(nproc)
 make install
 cd ..
+
+
+#---------------------------------
+
 
 #read -n1 -r -p "Press any key to build libvpx..." key
 
@@ -179,6 +211,10 @@ make -j$(nproc)
 make install
 i686-w64-mingw32-dlltool -m i386 -d libvpx.def -l /home/jim/packages/win32/bin/vpx.lib -D /home/jim/win32/packages/bin/libvpx-1.dll
 cd ..
+
+
+#---------------------------------
+
 
 read -n1 -r -p "Press any key to build FFmpeg..." key
 

--- a/win32.sh
+++ b/win32.sh
@@ -17,7 +17,7 @@ mkdir mbedtlsbuild/win32
 cd mbedtlsbuild/win32
 rm -rf *
 cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
-make -j6
+make -j$(nproc)
 i686-w64-mingw32-dlltool -z mbedtls.orig.def --export-all-symbols library/libmbedtls.dll
 i686-w64-mingw32-dlltool -z mbedcrypto.orig.def --export-all-symbols library/libmbedcrypto.dll
 i686-w64-mingw32-dlltool -z mbedx509.orig.def --export-all-symbols library/libmbedx509.dll
@@ -102,7 +102,7 @@ mkdir srtbuild/win32
 cd srtbuild/win32
 rm -rf *
 cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_CXX_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="/home/jim/packages/win32/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="/home/jim/packages/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
-make -j6
+make -j$(nproc)
 i686-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
 cd ../..
@@ -112,7 +112,7 @@ read -n1 -r -p "Press any key to build x264..." key
 cd x264
 make clean
 LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=i686-w64-mingw32- --host=i686-pc-mingw32 --prefix="/home/jim/packages/win32"
-make -j6
+make -j$(nproc)
 make install
 i686-w64-mingw32-dlltool -z /home/jim/packages/win32/bin/x264.orig.def --export-all-symbols /home/jim/packages/win32/bin/libx264-157.dll
 grep "EXPORTS\|x264" /home/jim/packages/win32/bin/x264.orig.def > /home/jim/packages/win32/bin/x264.def
@@ -126,7 +126,7 @@ cd ..
 cd opus
 make clean
 LDFLAGS="-static-libgcc" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -135,7 +135,7 @@ cd ..
 cd zlib/build32
 make clean
 cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DINSTALL_PKGCONFIG_DIR=/home/jim/packages/win32/lib/pkgconfig -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
-make -j6
+make -j$(nproc)
 make install
 mv ../../win32/lib/libzlib.dll.a ../../win32/lib/libz.dll.a
 mv ../../win32/lib/libzlibstatic.a ../../win32/lib/libz.a
@@ -148,7 +148,7 @@ cd ../..
 cd libpng
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -157,7 +157,7 @@ cd ..
 cd libogg
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -166,7 +166,7 @@ cd ..
 cd libvorbis
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared --with-ogg="/home/jim/packages/win32"
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -175,7 +175,7 @@ cd ..
 cd libvpxbuild
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" CROSS=i686-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=/home/jim/packages/win32 --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86-win32-gcc
-make -j6
+make -j$(nproc)
 make install
 i686-w64-mingw32-dlltool -m i386 -d libvpx.def -l /home/jim/packages/win32/bin/vpx.lib -D /home/jim/win32/packages/bin/libvpx-1.dll
 cd ..
@@ -194,6 +194,6 @@ cd ffmpeg
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CFLAGS="-I/home/jim/packages/win32/include -I/home/jim/packages/pthread-win32" ./configure --enable-gpl --disable-programs --disable-doc --arch=x86 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=i686-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="/home/jim/packages/win32" --disable-postproc
 read -n1 -r -p "Press any key to continue building FFmpeg..." key
-make -j6
+make -j$(nproc)
 make install
 cd ..

--- a/win32.sh
+++ b/win32.sh
@@ -10,6 +10,11 @@ mkdir lib
 cd ..
 mkdir -p win32/lib/pkgconfig
 
+# set build prefix
+WORKDIR=$PWD
+PREFIX=$PWD/win32
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+
 
 #---------------------------------
 
@@ -20,7 +25,7 @@ mkdir mbedtlsbuild
 mkdir mbedtlsbuild/win32
 cd mbedtlsbuild/win32
 rm -rf *
-cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
+cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
 make -j$(nproc)
 i686-w64-mingw32-dlltool -z mbedtls.orig.def --export-all-symbols library/libmbedtls.dll
 i686-w64-mingw32-dlltool -z mbedcrypto.orig.def --export-all-symbols library/libmbedcrypto.dll
@@ -31,16 +36,16 @@ grep "EXPORTS\|mbedtls" mbedx509.orig.def > mbedx509.def
 sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedtls.def
 sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedcrypto.def
 sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedx509.def
-i686-w64-mingw32-dlltool -m i386 -d mbedtls.def -l /home/jim/packages/win32/bin/mbedtls.lib -D library/libmbedtls.dll
-i686-w64-mingw32-dlltool -m i386 -d mbedcrypto.def -l /home/jim/packages/win32/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
-i686-w64-mingw32-dlltool -m i386 -d mbedx509.def -l /home/jim/packages/win32/bin/mbedx509.lib -D library/libmbedx509.dll
+i686-w64-mingw32-dlltool -m i386 -d mbedtls.def -l $PREFIX/bin/mbedtls.lib -D library/libmbedtls.dll
+i686-w64-mingw32-dlltool -m i386 -d mbedcrypto.def -l $PREFIX/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
+i686-w64-mingw32-dlltool -m i386 -d mbedx509.def -l $PREFIX/bin/mbedx509.lib -D library/libmbedx509.dll
 make install
 cd ../..
 
-mv win32/lib/*.dll win32/bin
+mv $PREFIX/lib/*.dll $PREFIX/bin
 
-cat > win32/lib/pkgconfig/mbedtls.pc <<EOF
-prefix=/home/jim/packages/win32
+cat > $PKG_CONFIG_PATH/mbedtls.pc <<EOF
+prefix=$PREFIX
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
@@ -54,8 +59,8 @@ Libs: -L\${libdir} -lmbedtls
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
-cat > win32/lib/pkgconfig/mbedcrypto.pc <<EOF
-prefix=/home/jim/packages/win32
+cat > $PKG_CONFIG_PATH/mbedcrypto.pc <<EOF
+prefix=$PREFIX
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
@@ -69,8 +74,8 @@ Libs: -L\${libdir} -lmbedcrypto
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
-cat > win32/lib/pkgconfig/mbedx509.pc <<EOF
-prefix=/home/jim/packages/win32
+cat > $PKG_CONFIG_PATH/mbedx509.pc <<EOF
+prefix=$PREFIX
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
@@ -91,8 +96,8 @@ EOF
 read -n1 -r -p "Press any key to build pthread-win32..." key
 
 cd pthread-win32
-make DESTROOT=/home/jim/packages/win32 CROSS=i686-w64-mingw32- realclean GC-small-static
-cp libpthreadGC2.a /home/jim/packages/win32/lib
+make DESTROOT=$PREFIX CROSS=i686-w64-mingw32- realclean GC-small-static
+cp libpthreadGC2.a $PREFIX/lib
 cd ..
 
 
@@ -105,7 +110,7 @@ mkdir srtbuild
 mkdir srtbuild/win32
 cd srtbuild/win32
 rm -rf *
-cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_CXX_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="/home/jim/packages/win32/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="/home/jim/packages/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
+cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_CXX_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="$PREFIX/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="$WORKDIR/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
 make -j$(nproc)
 i686-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
@@ -119,14 +124,14 @@ read -n1 -r -p "Press any key to build x264..." key
 
 cd x264
 make clean
-LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=i686-w64-mingw32- --host=i686-pc-mingw32 --prefix="/home/jim/packages/win32"
+LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=i686-w64-mingw32- --host=i686-pc-mingw32 --prefix="$PREFIX"
 make -j$(nproc)
 make install
-i686-w64-mingw32-dlltool -z /home/jim/packages/win32/bin/x264.orig.def --export-all-symbols /home/jim/packages/win32/bin/libx264-157.dll
-grep "EXPORTS\|x264" /home/jim/packages/win32/bin/x264.orig.def > /home/jim/packages/win32/bin/x264.def
-rm -f /home/jim/packages/win32/bin/x264.org.def
-sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" /home/jim/packages/win32/bin/x264.def
-i686-w64-mingw32-dlltool -m i386 -d /home/jim/packages/win32/bin/x264.def -l /home/jim/packages/win32/bin/x264.lib -D /home/jim/win32/packages/bin/libx264-157.dll
+i686-w64-mingw32-dlltool -z $PREFIX/bin/x264.orig.def --export-all-symbols $PREFIX/bin/libx264-157.dll
+grep "EXPORTS\|x264" $PREFIX/bin/x264.orig.def > $PREFIX/bin/x264.def
+rm -f $PREFIX/bin/x264.org.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" $PREFIX/bin/x264.def
+i686-w64-mingw32-dlltool -m i386 -d $PREFIX/bin/x264.def -l $PREFIX/bin/x264.lib -D $PREFIX/bin/libx264-157.dll
 cd ..
 
 
@@ -137,7 +142,7 @@ cd ..
 
 cd opus
 make clean
-LDFLAGS="-static-libgcc" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+LDFLAGS="-static-libgcc" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -150,13 +155,13 @@ cd ..
 
 cd zlib/build32
 make clean
-cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win32 -DINSTALL_PKGCONFIG_DIR=/home/jim/packages/win32/lib/pkgconfig -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
+cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DINSTALL_PKGCONFIG_DIR=$PREFIX/lib/pkgconfig -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
 make -j$(nproc)
 make install
-mv ../../win32/lib/libzlib.dll.a ../../win32/lib/libz.dll.a
-mv ../../win32/lib/libzlibstatic.a ../../win32/lib/libz.a
-cp ../win32/zlib.def /home/jim/packages/win32/bin
-i686-w64-mingw32-dlltool -m i386 -d ../win32/zlib.def -l /home/jim/packages/win32/bin/zlib.lib -D /home/jim/win32/packages/bin/zlib.dll
+mv $PREFIX/lib/libzlib.dll.a $PREFIX/lib/libz.dll.a
+mv $PREFIX/lib/libzlibstatic.a $PREFIX/lib/libz.a
+cp ../win32/zlib.def $PREFIX/bin
+i686-w64-mingw32-dlltool -m i386 -d ../win32/zlib.def -l $PREFIX/bin/zlib.lib -D $PREFIX/bin/zlib.dll
 cd ../..
 
 
@@ -167,7 +172,7 @@ cd ../..
 
 cd libpng
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -180,7 +185,7 @@ cd ..
 
 cd libogg
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -193,7 +198,7 @@ cd ..
 
 cd libvorbis
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared --with-ogg="/home/jim/packages/win32"
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared --with-ogg="$PREFIX"
 make -j$(nproc)
 make install
 cd ..
@@ -206,10 +211,10 @@ cd ..
 
 cd libvpxbuild
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" CROSS=i686-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=/home/jim/packages/win32 --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86-win32-gcc
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CROSS=i686-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=$PREFIX --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86-win32-gcc
 make -j$(nproc)
 make install
-i686-w64-mingw32-dlltool -m i386 -d libvpx.def -l /home/jim/packages/win32/bin/vpx.lib -D /home/jim/win32/packages/bin/libvpx-1.dll
+i686-w64-mingw32-dlltool -m i386 -d libvpx.def -l $PREFIX/bin/vpx.lib -D /home/jim/win32/packages/bin/libvpx-1.dll
 cd ..
 
 
@@ -219,16 +224,16 @@ cd ..
 read -n1 -r -p "Press any key to build FFmpeg..." key
 
 cd nv-codec-headers
-make PREFIX="/home/jim/packages/win32"
-make PREFIX="/home/jim/packages/win32" install
+make PREFIX="$PREFIX"
+make PREFIX="$PREFIX" install
 cd ..
 
-mkdir win32/include/AMF
-cp -a AMF/amf/public/include/* /home/jim/packages/win32/include/AMF
+mkdir $PREFIX/include/AMF
+cp -a AMF/amf/public/include/* $PREFIX/include/AMF
 
 cd ffmpeg
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CFLAGS="-I/home/jim/packages/win32/include -I/home/jim/packages/pthread-win32" ./configure --enable-gpl --disable-programs --disable-doc --arch=x86 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=i686-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="/home/jim/packages/win32" --disable-postproc
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CFLAGS="-I$PREFIX/include -I$WORKDIR/pthread-win32" ./configure --enable-gpl --disable-programs --disable-doc --arch=x86 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=i686-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="$PREFIX" --disable-postproc
 read -n1 -r -p "Press any key to continue building FFmpeg..." key
 make -j$(nproc)
 make install

--- a/win32.sh
+++ b/win32.sh
@@ -125,7 +125,7 @@ cd ..
 
 cd opus
 make clean
-LDFLAGS="-static-libgcc" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+LDFLAGS="-static-libgcc" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -147,7 +147,7 @@ cd ../..
 
 cd libpng
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -156,7 +156,7 @@ cd ..
 
 cd libogg
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -165,7 +165,7 @@ cd ..
 
 cd libvorbis
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure -host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared --with-ogg="/home/jim/packages/win32"
+PKG_CONFIG_PATH="/home/jim/packages/win32/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win32/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win32/include" ./configure --host=i686-w64-mingw32 --prefix="/home/jim/packages/win32" --enable-shared --with-ogg="/home/jim/packages/win32"
 make -j$(nproc)
 make install
 cd ..

--- a/win32.sh
+++ b/win32.sh
@@ -15,12 +15,17 @@ WORKDIR=$PWD
 PREFIX=$PWD/win32
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
 
+# set variables
+SKIP_PROMPTS=true
+
 
 #---------------------------------
 
 
 # start mbedTLS
-read -n1 -r -p "Press any key to build mbedtls..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build mbedtls..." key
+fi
 
 # download mbedTLS
 curl --retry 5 -L -o mbedtls-2.23.0.tar.gz https://github.com/ARMmbed/mbedtls/archive/v2.23.0.tar.gz
@@ -106,7 +111,9 @@ EOF
 
 
 # pthread-win32
-read -n1 -r -p "Press any key to build pthread-win32..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build pthread-win32..." key
+fi
 
 # download pthread-win32
 curl --retry 5 -L -o pthread-win32-master.zip https://github.com/GerHobbelt/pthread-win32/archive/master.zip
@@ -123,7 +130,10 @@ cd ..
 #---------------------------------
 
 
-read -n1 -r -p "Press any key to build libsrt..." key
+# libsrt
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libsrt..." key
+fi
 
 # download libsrt
 curl --retry 5 -L -o srt-v1.4.1.tar.gz https://github.com/Haivision/srt/archive/v1.4.1.tar.gz
@@ -145,7 +155,9 @@ cd ../..
 
 
 # x264
-read -n1 -r -p "Press any key to build x264..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build x264..." key
+fi
 
 # download and prep x264
 git clone https://code.videolan.org/videolan/x264.git
@@ -170,7 +182,9 @@ cd ..
 
 
 # opus
-#read -n1 -r -p "Press any key to build opus..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build opus..." key
+fi
 
 # download opus
 curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.3.1.tar.gz
@@ -190,7 +204,9 @@ cd ..
 
 
 # zlib
-#read -n1 -r -p "Press any key to build zlib..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build zlib..." key
+fi
 
 # download zlib
 curl --retry 5 -L -O https://www.zlib.net/zlib-1.2.11.tar.gz
@@ -224,7 +240,9 @@ cd $WORKDIR
 
 
 # libpng
-#read -n1 -r -p "Press any key to build libpng..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libpng..." key
+fi
 
 # download libpng
 curl --retry 5 -L -o libpng-1.6.37.tar.gz https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
@@ -244,7 +262,9 @@ cd ..
 
 
 # libogg
-#read -n1 -r -p "Press any key to build libogg..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libogg..." key
+fi
 
 # download libogg
 curl --retry 5 -L -o ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz https://gitlab.xiph.org/xiph/ogg/-/archive/68ca3841567247ac1f7850801a164f58738d8df9/ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz
@@ -267,7 +287,9 @@ cd ../..
 
 
 # libvorbis
-#read -n1 -r -p "Press any key to build libvorbis..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libvorbis..." key
+fi
 
 # download libvorbis
 curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.6.tar.gz
@@ -287,7 +309,9 @@ cd ..
 
 
 # libvpx
-#read -n1 -r -p "Press any key to build libvpx..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libvpx..." key
+fi
 
 # download libvpx
 curl --retry 5 -L -o libvpx-v1.8.1.tar.gz https://chromium.googlesource.com/webm/libvpx/+archive/v1.8.1.tar.gz
@@ -314,7 +338,9 @@ pkg-config --libs vpx
 
 
 # FFmpeg
-read -n1 -r -p "Press any key to build FFmpeg..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build FFmpeg..." key
+fi
 
 # nv-codec-headers
 # download nv-codec-headers
@@ -342,7 +368,9 @@ cd ffmpeg
 patch -p1 < ../patch/ffmpeg/ffmpeg_flvdec.patch
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CFLAGS="-I$PREFIX/include -I$WORKDIR/pthread-win32" ./configure --enable-gpl --disable-programs --disable-doc --arch=x86 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=i686-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="$PREFIX" --disable-postproc
-read -n1 -r -p "Press any key to continue building FFmpeg..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to continue building FFmpeg..." key
+fi
 make -j$(nproc)
 make install
 cd ..

--- a/win32.sh
+++ b/win32.sh
@@ -189,9 +189,21 @@ cd ..
 #---------------------------------
 
 
+# zlib
 #read -n1 -r -p "Press any key to build zlib..." key
 
-cd zlib/build32
+# download zlib
+curl --retry 5 -L -O https://www.zlib.net/zlib-1.2.11.tar.gz
+tar -xf zlib-1.2.11.tar.gz
+mv zlib-1.2.11 zlib
+
+# patch CMakeLists.txt to remove the "lib" prefix when building shared libraries
+cd zlib
+patch -p1 < $WORKDIR/patch/zlib/zlib-disable-shared-lib-prefix.patch
+
+# build zlib
+mkdir build32
+cd build32
 make clean
 cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DINSTALL_PKGCONFIG_DIR=$PREFIX/lib/pkgconfig -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
 make -j$(nproc)
@@ -201,6 +213,11 @@ mv $PREFIX/lib/libzlibstatic.a $PREFIX/lib/libz.a
 cp ../win32/zlib.def $PREFIX/bin
 i686-w64-mingw32-dlltool -m i386 -d ../win32/zlib.def -l $PREFIX/bin/zlib.lib -D $PREFIX/bin/zlib.dll
 cd ../..
+
+# patch include/zconf.h
+cd $PREFIX
+patch -p1 < $WORKDIR/patch/zlib/zlib-include-zconf.patch
+cd $WORKDIR
 
 
 #---------------------------------

--- a/win32.sh
+++ b/win32.sh
@@ -125,11 +125,16 @@ cd ..
 
 read -n1 -r -p "Press any key to build libsrt..." key
 
-mkdir srtbuild
-mkdir srtbuild/win32
+# download libsrt
+curl --retry 5 -L -o srt-v1.4.1.tar.gz https://github.com/Haivision/srt/archive/v1.4.1.tar.gz
+tar -xf srt-v1.4.1.tar.gz
+mv srt-1.4.1 srt
+
+# build libsrt
+mkdir -p srtbuild/win32
 cd srtbuild/win32
 rm -rf *
-cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_CXX_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="$PREFIX/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="$WORKDIR/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
+cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_CXX_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="$PREFIX/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="$WORKDIR/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
 make -j$(nproc)
 i686-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install

--- a/win32.sh
+++ b/win32.sh
@@ -19,10 +19,21 @@ export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
 #---------------------------------
 
 
+# start mbedTLS
 read -n1 -r -p "Press any key to build mbedtls..." key
 
-mkdir mbedtlsbuild
-mkdir mbedtlsbuild/win32
+# download mbedTLS
+curl --retry 5 -L -o mbedtls-2.23.0.tar.gz https://github.com/ARMmbed/mbedtls/archive/v2.23.0.tar.gz
+tar -xf mbedtls-2.23.0.tar.gz
+mv mbedtls-2.23.0 mbedtls
+
+# build mbedTLS
+# Enable the threading abstraction layer and use an alternate implementation
+sed -i -e "s/\/\/#define MBEDTLS_THREADING_C/#define MBEDTLS_THREADING_C/" \
+-e "s/\/\/#define MBEDTLS_THREADING_ALT/#define MBEDTLS_THREADING_ALT/" mbedtls/include/mbedtls/config.h
+cp -p patch/mbedtls/threading_alt.h mbedtls/include/mbedtls/threading_alt.h
+
+mkdir -p mbedtlsbuild/win32
 cd mbedtlsbuild/win32
 rm -rf *
 cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
@@ -44,6 +55,7 @@ cd ../..
 
 mv $PREFIX/lib/*.dll $PREFIX/bin
 
+# create pkgconfig files for mbedTLS
 cat > $PKG_CONFIG_PATH/mbedtls.pc <<EOF
 prefix=$PREFIX
 exec_prefix=\${prefix}

--- a/win32.sh
+++ b/win32.sh
@@ -243,14 +243,24 @@ cd ..
 #---------------------------------
 
 
+# libogg
 #read -n1 -r -p "Press any key to build libogg..." key
 
+# download libogg
+curl --retry 5 -L -o ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz https://gitlab.xiph.org/xiph/ogg/-/archive/68ca3841567247ac1f7850801a164f58738d8df9/ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz
+tar -xf ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz
+mv ogg-68ca3841567247ac1f7850801a164f58738d8df9 libogg
+
+# build libogg
 cd libogg
+mkdir build32
+./autogen.sh
+cd build32
 make clean
-PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ../configure --host=i686-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
-cd ..
+cd ../..
 
 
 #---------------------------------

--- a/win32.sh
+++ b/win32.sh
@@ -10,7 +10,7 @@ mkdir lib
 cd ..
 mkdir -p win32/lib/pkgconfig
 
-read -n1 -r -p "Press any key to build mbedtls.." key
+read -n1 -r -p "Press any key to build mbedtls..." key
 
 mkdir mbedtlsbuild
 mkdir mbedtlsbuild/win32
@@ -88,14 +88,14 @@ EOF
 
 #---------------------------------
 
-read -n1 -r -p "Press any key to build pthread-win32.." key
+read -n1 -r -p "Press any key to build pthread-win32..." key
 
 cd pthread-win32
 make DESTROOT=/home/jim/packages/win32 CROSS=i686-w64-mingw32- realclean GC-small-static
 cp libpthreadGC2.a /home/jim/packages/win32/lib
 cd ..
 
-read -n1 -r -p "Press any key to build libsrt.." key
+read -n1 -r -p "Press any key to build libsrt..." key
 
 mkdir srtbuild
 mkdir srtbuild/win32

--- a/win32.sh
+++ b/win32.sh
@@ -286,8 +286,19 @@ cd ..
 #---------------------------------
 
 
+# libvpx
 #read -n1 -r -p "Press any key to build libvpx..." key
 
+# download libvpx
+curl --retry 5 -L -o libvpx-v1.8.1.tar.gz https://chromium.googlesource.com/webm/libvpx/+archive/v1.8.1.tar.gz
+mkdir -p libvpx
+tar -xf libvpx-v1.8.1.tar.gz -C $PWD/libvpx
+
+# build libvpx
+cd libvpx
+patch -p1 < ../patch/libvpx/libvpx-crosscompile-win-dll.patch
+cd ..
+mkdir -p libvpxbuild
 cd libvpxbuild
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CROSS=i686-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=$PREFIX --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86-win32-gcc
@@ -295,6 +306,8 @@ make -j$(nproc)
 make install
 i686-w64-mingw32-dlltool -m i386 -d libvpx.def -l $PREFIX/bin/vpx.lib -D /home/jim/win32/packages/bin/libvpx-1.dll
 cd ..
+
+pkg-config --libs vpx
 
 
 #---------------------------------

--- a/win64.sh
+++ b/win64.sh
@@ -1,0 +1,202 @@
+#/bin/bash
+
+rm -rf win64
+mkdir win64
+cd win64
+mkdir bin
+mkdir include
+mkdir lib
+cd ..
+
+read -n1 -r -p "Press any key to build mbedtls.." key
+
+mkdir mbedtlsbuild
+mkdir mbedtlsbuild/win64
+cd mbedtlsbuild/win64
+rm -rf *
+cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
+make -j6
+x86_64-w64-mingw32-dlltool -z mbedtls.orig.def --export-all-symbols library/libmbedtls.dll
+x86_64-w64-mingw32-dlltool -z mbedcrypto.orig.def --export-all-symbols library/libmbedcrypto.dll
+x86_64-w64-mingw32-dlltool -z mbedx509.orig.def --export-all-symbols library/libmbedx509.dll
+grep "EXPORTS\|mbedtls" mbedtls.orig.def > mbedtls.def
+grep "EXPORTS\|mbedtls" mbedcrypto.orig.def > mbedcrypto.def
+grep "EXPORTS\|mbedtls" mbedx509.orig.def > mbedx509.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedtls.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedcrypto.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedx509.def
+x86_64-w64-mingw32-dlltool -z mbedtls.def --export-all-symbols library/libmbedtls.dll
+x86_64-w64-mingw32-dlltool -z mbedcrypto.def --export-all-symbols library/libmbedcrypto.dll
+x86_64-w64-mingw32-dlltool -z mbedx509.def --export-all-symbols library/libmbedx509.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedtls.def -l /home/jim/packages/win64/bin/mbedtls.lib -D library/libmbedtls.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedcrypto.def -l /home/jim/packages/win64/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedx509.def -l /home/jim/packages/win64/bin/mbedx509.lib -D library/libmbedx509.dll
+make install
+cd ../..
+
+mv win64/lib/*.dll win64/bin
+mkdir win64/lib/pkgconfig
+
+#---------------------------------
+
+cat > win64/lib/pkgconfig/mbedtls.pc <<EOF
+prefix=/home/jim/packages/win64
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: mbedtls
+Description:
+Version: 1.0.0
+Requires:
+Conflicts:
+Libs: -L\${libdir} -lmbedtls
+Cflags: -I\${includedir} -I\${includedir}/mbedtls
+EOF
+
+#---------------------------------
+
+cat > win64/lib/pkgconfig/mbedcrypto.pc <<EOF
+prefix=/home/jim/packages/win64
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: mbedcrypto
+Description:
+Version: 1.0.0
+Requires:
+Conflicts:
+Libs: -L\${libdir} -lmbedcrypto
+Cflags: -I\${includedir} -I\${includedir}/mbedtls
+EOF
+
+#---------------------------------
+
+cat > win64/lib/pkgconfig/mbedx509.pc <<EOF
+prefix=/home/jim/packages/win64
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: mbedx509
+Description:
+Version: 1.0.0
+Requires:
+Conflicts:
+Libs: -L\${libdir} -lmbedx509
+Cflags: -I\${includedir} -I\${includedir}/mbedtls
+EOF
+
+#---------------------------------
+
+read -n1 -r -p "Press any key to build pthread-win32.." key
+
+cd pthread-win32
+make DESTROOT=/home/jim/packages/win64 CROSS=x86_64-w64-mingw32- realclean GC-small-static
+cp libpthreadGC2.a /home/jim/packages/win64/lib
+cd ..
+
+read -n1 -r -p "Press any key to build libsrt.." key
+
+mkdir srtbuild
+mkdir srtbuild/win64
+cd srtbuild/win64
+rm -rf *
+cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_CXX_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="/home/jim/packages/win64/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="/home/jim/packages/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
+make -j6
+x86_64-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
+make install
+cd ../..
+
+read -n1 -r -p "Press any key to build x264.." key
+
+cd x264
+make clean
+LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=x86_64-w64-mingw32- --host=x86_64-pc-mingw32 --prefix="/home/jim/packages/win64"
+# make -j6 fprofiled VIDS="CITY_704x576_60_orig_01.yuv"
+make -j6
+make install
+x86_64-w64-mingw32-dlltool -z /home/jim/packages/win64/bin/x264.orig.def --export-all-symbols /home/jim/packages/win64/bin/libx264-157.dll
+grep "EXPORTS\|x264" /home/jim/packages/win64/bin/x264.orig.def > /home/jim/packages/win64/bin/x264.def
+rm -f /home/jim/packages/win64/bin/x264.org.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" /home/jim/packages/win64/bin/x264.def
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d /home/jim/packages/win64/bin/x264.def -l /home/jim/packages/win64/bin/x264.lib -D /home/jim/win64/packages/bin/libx264-157.dll
+cd ..
+
+#read -n1 -r -p "Press any key to build opus..." key
+
+cd opus
+make clean
+LDFLAGS="-static-libgcc" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build zlib..." key
+
+cd zlib/build64
+make clean
+cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
+make -j6
+make install
+mv ../../win64/lib/libzlib.dll.a ../../win64/lib/libz.dll.a
+mv ../../win64/lib/libzlibstatic.a ../../win64/lib/libz.a
+cp ../win32/zlib.def /home/jim/packages/win64/bin
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d ../win32/zlib.def -l /home/jim/packages/win64/bin/zlib.lib -D /home/jim/win64/packages/bin/zlib.dll
+cd ../..
+
+#read -n1 -r -p "Press any key to build libpng..." key
+
+cd libpng
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build libogg..." key
+
+cd libogg
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build libvorbis..." key
+
+cd libvorbis
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared --with-ogg="/home/jim/packages/win64"
+make -j6
+make install
+cd ..
+
+#read -n1 -r -p "Press any key to build libvpx..." key
+
+cd libvpxbuild
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" CROSS=x86_64-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=/home/jim/packages/win64 --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86_64-win64-gcc
+make -j6
+make install
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d libvpx.def -l /home/jim/packages/win64/bin/vpx.lib -D /home/jim/win64/packages/bin/libvpx-1.dll
+cd ..
+
+read -n1 -r -p "Press any key to build FFmpeg..." key
+
+cd nv-codec-headers
+make PREFIX="/home/jim/packages/win64"
+make PREFIX="/home/jim/packages/win64" install
+cd ..
+
+mkdir win64/include/AMF
+cp -a AMF/amf/public/include/* /home/jim/packages/win64/include/AMF
+
+cd ffmpeg
+make clean
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include -I/home/jim/packages/pthread-win32" ./configure --enable-gpl --disable-doc --arch=x86_64 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="/home/jim/packages/win64" --disable-postproc
+read -n1 -r -p "Press any key to continue building FFmpeg..." key
+make -j6
+make install
+cd ..

--- a/win64.sh
+++ b/win64.sh
@@ -317,17 +317,33 @@ pkg-config --libs vpx
 #---------------------------------
 
 
+# FFmpeg
 read -n1 -r -p "Press any key to build FFmpeg..." key
 
+# nv-codec-headers
+# download nv-codec-headers
+git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
 cd nv-codec-headers
-make PREFIX="$PREFIX"
-make PREFIX="$PREFIX" install
+
+# build nv-codec-headers
+make PREFIX=$PREFIX
+make PREFIX=$PREFIX install
 cd ..
 
-mkdir $PREFIX/include/AMF
-cp -a AMF/amf/public/include/* $PREFIX/include/AMF
+# AMF
+# download/prep AMF
+git clone https://github.com/obsproject/obs-amd-encoder.git
+mkdir -p $PREFIX/include/AMF
+cp -a obs-amd-encoder/AMF/amf/public/include/* $PREFIX/include/AMF
 
+# download FFmpeg
+curl -L -o FFmpeg-n4.2.2.zip https://github.com/FFmpeg/FFmpeg/archive/n4.2.2.zip
+unzip FFmpeg-n4.2.2.zip
+mv FFmpeg-n4.2.2 ffmpeg
+
+# build FFmpeg
 cd ffmpeg
+patch -p1 < ../patch/ffmpeg/ffmpeg_flvdec.patch
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib" CPPFLAGS="-I$PREFIX/include -I$WORKDIR/pthread-win32" ./configure --enable-gpl --disable-doc --arch=x86_64 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="$PREFIX" --disable-postproc
 read -n1 -r -p "Press any key to continue building FFmpeg..." key

--- a/win64.sh
+++ b/win64.sh
@@ -129,7 +129,7 @@ cd ..
 
 cd opus
 make clean
-LDFLAGS="-static-libgcc" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+LDFLAGS="-static-libgcc" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -151,7 +151,7 @@ cd ../..
 
 cd libpng
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -160,7 +160,7 @@ cd ..
 
 cd libogg
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -169,7 +169,7 @@ cd ..
 
 cd libvorbis
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared --with-ogg="/home/jim/packages/win64"
+PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared --with-ogg="/home/jim/packages/win64"
 make -j$(nproc)
 make install
 cd ..

--- a/win64.sh
+++ b/win64.sh
@@ -109,8 +109,15 @@ EOF
 #---------------------------------
 
 
+# pthread-win32
 read -n1 -r -p "Press any key to build pthread-win32..." key
 
+# download pthread-win32
+curl --retry 5 -L -o pthread-win32-master.zip https://github.com/GerHobbelt/pthread-win32/archive/master.zip
+unzip pthread-win32-master.zip
+mv pthread-win32-master pthread-win32
+
+# build pthread-win32
 cd pthread-win32
 make DESTROOT=$PREFIX CROSS=x86_64-w64-mingw32- realclean GC-small-static
 cp libpthreadGC2.a $PREFIX/lib

--- a/win64.sh
+++ b/win64.sh
@@ -247,14 +247,24 @@ cd ..
 #---------------------------------
 
 
+# libogg
 #read -n1 -r -p "Press any key to build libogg..." key
 
+# download libogg
+curl --retry 5 -L -o ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz https://gitlab.xiph.org/xiph/ogg/-/archive/68ca3841567247ac1f7850801a164f58738d8df9/ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz
+tar -xf ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz
+mv ogg-68ca3841567247ac1f7850801a164f58738d8df9 libogg
+
+# build libogg
 cd libogg
+mkdir build64
+./autogen.sh
+cd build64
 make clean
-PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ../configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
-cd ..
+cd ../..
 
 
 #---------------------------------

--- a/win64.sh
+++ b/win64.sh
@@ -270,8 +270,15 @@ cd ../..
 #---------------------------------
 
 
+# libvorbis
 #read -n1 -r -p "Press any key to build libvorbis..." key
 
+# download libvorbis
+curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.6.tar.gz
+tar -xf libvorbis-1.3.6.tar.gz
+mv libvorbis-1.3.6 libvorbis
+
+# build libvorbis
 cd libvorbis
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared --with-ogg="$PREFIX"

--- a/win64.sh
+++ b/win64.sh
@@ -17,7 +17,7 @@ mkdir mbedtlsbuild/win64
 cd mbedtlsbuild/win64
 rm -rf *
 cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
-make -j6
+make -j$(nproc)
 x86_64-w64-mingw32-dlltool -z mbedtls.orig.def --export-all-symbols library/libmbedtls.dll
 x86_64-w64-mingw32-dlltool -z mbedcrypto.orig.def --export-all-symbols library/libmbedcrypto.dll
 x86_64-w64-mingw32-dlltool -z mbedx509.orig.def --export-all-symbols library/libmbedx509.dll
@@ -105,7 +105,7 @@ mkdir srtbuild/win64
 cd srtbuild/win64
 rm -rf *
 cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_CXX_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="/home/jim/packages/win64/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="/home/jim/packages/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
-make -j6
+make -j$(nproc)
 x86_64-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
 cd ../..
@@ -116,7 +116,7 @@ cd x264
 make clean
 LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=x86_64-w64-mingw32- --host=x86_64-pc-mingw32 --prefix="/home/jim/packages/win64"
 # make -j6 fprofiled VIDS="CITY_704x576_60_orig_01.yuv"
-make -j6
+make -j$(nproc)
 make install
 x86_64-w64-mingw32-dlltool -z /home/jim/packages/win64/bin/x264.orig.def --export-all-symbols /home/jim/packages/win64/bin/libx264-157.dll
 grep "EXPORTS\|x264" /home/jim/packages/win64/bin/x264.orig.def > /home/jim/packages/win64/bin/x264.def
@@ -130,7 +130,7 @@ cd ..
 cd opus
 make clean
 LDFLAGS="-static-libgcc" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -139,7 +139,7 @@ cd ..
 cd zlib/build64
 make clean
 cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
-make -j6
+make -j$(nproc)
 make install
 mv ../../win64/lib/libzlib.dll.a ../../win64/lib/libz.dll.a
 mv ../../win64/lib/libzlibstatic.a ../../win64/lib/libz.a
@@ -152,7 +152,7 @@ cd ../..
 cd libpng
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -161,7 +161,7 @@ cd ..
 cd libogg
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -170,7 +170,7 @@ cd ..
 cd libvorbis
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure -host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared --with-ogg="/home/jim/packages/win64"
-make -j6
+make -j$(nproc)
 make install
 cd ..
 
@@ -179,7 +179,7 @@ cd ..
 cd libvpxbuild
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" CROSS=x86_64-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=/home/jim/packages/win64 --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86_64-win64-gcc
-make -j6
+make -j$(nproc)
 make install
 x86_64-w64-mingw32-dlltool -m i386:x86-64 -d libvpx.def -l /home/jim/packages/win64/bin/vpx.lib -D /home/jim/win64/packages/bin/libvpx-1.dll
 cd ..
@@ -198,6 +198,6 @@ cd ffmpeg
 make clean
 PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include -I/home/jim/packages/pthread-win32" ./configure --enable-gpl --disable-doc --arch=x86_64 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="/home/jim/packages/win64" --disable-postproc
 read -n1 -r -p "Press any key to continue building FFmpeg..." key
-make -j6
+make -j$(nproc)
 make install
 cd ..

--- a/win64.sh
+++ b/win64.sh
@@ -227,8 +227,15 @@ cd $WORKDIR
 #---------------------------------
 
 
+# libpng
 #read -n1 -r -p "Press any key to build libpng..." key
 
+# download libpng
+curl --retry 5 -L -o libpng-1.6.37.tar.gz https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
+tar -xf libpng-1.6.37.tar.gz
+mv libpng-1.6.37 libpng
+
+# build libpng
 cd libpng
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib" CPPFLAGS="-I$PREFIX/include" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared

--- a/win64.sh
+++ b/win64.sh
@@ -173,8 +173,15 @@ cd ..
 #---------------------------------
 
 
+# opus
 #read -n1 -r -p "Press any key to build opus..." key
 
+# download opus
+curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.3.1.tar.gz
+tar -xf opus-1.3.1.tar.gz
+mv opus-1.3.1 opus
+
+# build opus
 cd opus
 make clean
 LDFLAGS="-static-libgcc" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared

--- a/win64.sh
+++ b/win64.sh
@@ -148,19 +148,25 @@ cd ../..
 #---------------------------------
 
 
+# x264
 read -n1 -r -p "Press any key to build x264..." key
 
+# download and prep x264
+git clone https://code.videolan.org/videolan/x264.git
 cd x264
+git checkout 72db437770fd1ce3961f624dd57a8e75ff65ae0b
+
+# build x264
+x264_api="$(grep '#define X264_BUILD' < x264.h | sed 's/^.* \([1-9][0-9]*\).*$/\1/')"
 make clean
 LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=x86_64-w64-mingw32- --host=x86_64-pc-mingw32 --prefix="$PREFIX"
-# make -j6 fprofiled VIDS="CITY_704x576_60_orig_01.yuv"
 make -j$(nproc)
 make install
-x86_64-w64-mingw32-dlltool -z $PREFIX/bin/x264.orig.def --export-all-symbols $PREFIX/bin/libx264-157.dll
+x86_64-w64-mingw32-dlltool -z $PREFIX/bin/x264.orig.def --export-all-symbols $PREFIX/bin/libx264-$x264_api.dll
 grep "EXPORTS\|x264" $PREFIX/bin/x264.orig.def > $PREFIX/bin/x264.def
-rm -f $PREFIX/bin/x264.org.def
+rm -f $PREFIX/bin/x264.orig.def
 sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" $PREFIX/bin/x264.def
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d $PREFIX/bin/x264.def -l $PREFIX/bin/x264.lib -D $PREFIX/bin/libx264-157.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d $PREFIX/bin/x264.def -l $PREFIX/bin/x264.lib -D $PREFIX/bin/libx264-$x264_api.dll
 cd ..
 
 

--- a/win64.sh
+++ b/win64.sh
@@ -10,6 +10,10 @@ mkdir lib
 cd ..
 mkdir -p win64/lib/pkgconfig
 
+
+#---------------------------------
+
+
 read -n1 -r -p "Press any key to build mbedtls..." key
 
 mkdir mbedtlsbuild
@@ -38,8 +42,6 @@ cd ../..
 
 mv win64/lib/*.dll win64/bin
 
-#---------------------------------
-
 cat > win64/lib/pkgconfig/mbedtls.pc <<EOF
 prefix=/home/jim/packages/win64
 exec_prefix=\${prefix}
@@ -54,8 +56,6 @@ Conflicts:
 Libs: -L\${libdir} -lmbedtls
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
-
-#---------------------------------
 
 cat > win64/lib/pkgconfig/mbedcrypto.pc <<EOF
 prefix=/home/jim/packages/win64
@@ -72,8 +72,6 @@ Libs: -L\${libdir} -lmbedcrypto
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
-#---------------------------------
-
 cat > win64/lib/pkgconfig/mbedx509.pc <<EOF
 prefix=/home/jim/packages/win64
 exec_prefix=\${prefix}
@@ -89,7 +87,9 @@ Libs: -L\${libdir} -lmbedx509
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
+
 #---------------------------------
+
 
 read -n1 -r -p "Press any key to build pthread-win32..." key
 
@@ -97,6 +97,10 @@ cd pthread-win32
 make DESTROOT=/home/jim/packages/win64 CROSS=x86_64-w64-mingw32- realclean GC-small-static
 cp libpthreadGC2.a /home/jim/packages/win64/lib
 cd ..
+
+
+#---------------------------------
+
 
 read -n1 -r -p "Press any key to build libsrt..." key
 
@@ -109,6 +113,10 @@ make -j$(nproc)
 x86_64-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
 cd ../..
+
+
+#---------------------------------
+
 
 read -n1 -r -p "Press any key to build x264..." key
 
@@ -125,6 +133,10 @@ sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" /home/jim/packages/win64
 x86_64-w64-mingw32-dlltool -m i386:x86-64 -d /home/jim/packages/win64/bin/x264.def -l /home/jim/packages/win64/bin/x264.lib -D /home/jim/win64/packages/bin/libx264-157.dll
 cd ..
 
+
+#---------------------------------
+
+
 #read -n1 -r -p "Press any key to build opus..." key
 
 cd opus
@@ -133,6 +145,10 @@ LDFLAGS="-static-libgcc" ./configure --host=x86_64-w64-mingw32 --prefix="/home/j
 make -j$(nproc)
 make install
 cd ..
+
+
+#---------------------------------
+
 
 #read -n1 -r -p "Press any key to build zlib..." key
 
@@ -147,6 +163,10 @@ cp ../win32/zlib.def /home/jim/packages/win64/bin
 x86_64-w64-mingw32-dlltool -m i386:x86-64 -d ../win32/zlib.def -l /home/jim/packages/win64/bin/zlib.lib -D /home/jim/win64/packages/bin/zlib.dll
 cd ../..
 
+
+#---------------------------------
+
+
 #read -n1 -r -p "Press any key to build libpng..." key
 
 cd libpng
@@ -155,6 +175,10 @@ PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/pa
 make -j$(nproc)
 make install
 cd ..
+
+
+#---------------------------------
+
 
 #read -n1 -r -p "Press any key to build libogg..." key
 
@@ -165,6 +189,10 @@ make -j$(nproc)
 make install
 cd ..
 
+
+#---------------------------------
+
+
 #read -n1 -r -p "Press any key to build libvorbis..." key
 
 cd libvorbis
@@ -173,6 +201,10 @@ PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/pa
 make -j$(nproc)
 make install
 cd ..
+
+
+#---------------------------------
+
 
 #read -n1 -r -p "Press any key to build libvpx..." key
 
@@ -183,6 +215,10 @@ make -j$(nproc)
 make install
 x86_64-w64-mingw32-dlltool -m i386:x86-64 -d libvpx.def -l /home/jim/packages/win64/bin/vpx.lib -D /home/jim/win64/packages/bin/libvpx-1.dll
 cd ..
+
+
+#---------------------------------
+
 
 read -n1 -r -p "Press any key to build FFmpeg..." key
 

--- a/win64.sh
+++ b/win64.sh
@@ -290,8 +290,19 @@ cd ..
 #---------------------------------
 
 
+# libvpx
 #read -n1 -r -p "Press any key to build libvpx..." key
 
+# download libvpx
+curl --retry 5 -L -o libvpx-v1.8.1.tar.gz https://chromium.googlesource.com/webm/libvpx/+archive/v1.8.1.tar.gz
+mkdir -p libvpx
+tar -xf libvpx-v1.8.1.tar.gz -C $PWD/libvpx
+
+# build libvpx
+cd libvpx
+patch -p1 < ../patch/libvpx/libvpx-crosscompile-win-dll.patch
+cd ..
+mkdir -p libvpxbuild
 cd libvpxbuild
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CROSS=x86_64-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=$PREFIX --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86_64-win64-gcc
@@ -299,6 +310,8 @@ make -j$(nproc)
 make install
 x86_64-w64-mingw32-dlltool -m i386:x86-64 -d libvpx.def -l $PREFIX/bin/vpx.lib -D /home/jim/win64/packages/bin/libvpx-1.dll
 cd ..
+
+pkg-config --libs vpx
 
 
 #---------------------------------

--- a/win64.sh
+++ b/win64.sh
@@ -129,11 +129,16 @@ cd ..
 
 read -n1 -r -p "Press any key to build libsrt..." key
 
-mkdir srtbuild
-mkdir srtbuild/win64
+# download libsrt
+curl --retry 5 -L -o srt-v1.4.1.tar.gz https://github.com/Haivision/srt/archive/v1.4.1.tar.gz
+tar -xf srt-v1.4.1.tar.gz
+mv srt-1.4.1 srt
+
+# build libsrt
+mkdir -p srtbuild/win64
 cd srtbuild/win64
 rm -rf *
-cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_CXX_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="$PREFIX/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="$WORKDIR/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
+cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_CXX_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="$PREFIX/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="$WORKDIR/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
 make -j$(nproc)
 x86_64-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install

--- a/win64.sh
+++ b/win64.sh
@@ -1,5 +1,6 @@
 #/bin/bash
 
+# make directories
 rm -rf win64
 mkdir win64
 cd win64
@@ -7,6 +8,7 @@ mkdir bin
 mkdir include
 mkdir lib
 cd ..
+mkdir -p win64/lib/pkgconfig
 
 read -n1 -r -p "Press any key to build mbedtls.." key
 
@@ -35,7 +37,6 @@ make install
 cd ../..
 
 mv win64/lib/*.dll win64/bin
-mkdir win64/lib/pkgconfig
 
 #---------------------------------
 

--- a/win64.sh
+++ b/win64.sh
@@ -10,7 +10,7 @@ mkdir lib
 cd ..
 mkdir -p win64/lib/pkgconfig
 
-read -n1 -r -p "Press any key to build mbedtls.." key
+read -n1 -r -p "Press any key to build mbedtls..." key
 
 mkdir mbedtlsbuild
 mkdir mbedtlsbuild/win64
@@ -91,14 +91,14 @@ EOF
 
 #---------------------------------
 
-read -n1 -r -p "Press any key to build pthread-win32.." key
+read -n1 -r -p "Press any key to build pthread-win32..." key
 
 cd pthread-win32
 make DESTROOT=/home/jim/packages/win64 CROSS=x86_64-w64-mingw32- realclean GC-small-static
 cp libpthreadGC2.a /home/jim/packages/win64/lib
 cd ..
 
-read -n1 -r -p "Press any key to build libsrt.." key
+read -n1 -r -p "Press any key to build libsrt..." key
 
 mkdir srtbuild
 mkdir srtbuild/win64
@@ -110,7 +110,7 @@ x86_64-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
 cd ../..
 
-read -n1 -r -p "Press any key to build x264.." key
+read -n1 -r -p "Press any key to build x264..." key
 
 cd x264
 make clean

--- a/win64.sh
+++ b/win64.sh
@@ -15,12 +15,17 @@ WORKDIR=$PWD
 PREFIX=$PWD/win64
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
 
+# set variables
+SKIP_PROMPTS=true
+
 
 #---------------------------------
 
 
 # start mbedTLS
-read -n1 -r -p "Press any key to build mbedtls..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build mbedtls..." key
+fi
 
 # download mbedTLS
 curl --retry 5 -L -o mbedtls-2.23.0.tar.gz https://github.com/ARMmbed/mbedtls/archive/v2.23.0.tar.gz
@@ -110,7 +115,9 @@ EOF
 
 
 # pthread-win32
-read -n1 -r -p "Press any key to build pthread-win32..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build pthread-win32..." key
+fi
 
 # download pthread-win32
 curl --retry 5 -L -o pthread-win32-master.zip https://github.com/GerHobbelt/pthread-win32/archive/master.zip
@@ -127,7 +134,10 @@ cd ..
 #---------------------------------
 
 
-read -n1 -r -p "Press any key to build libsrt..." key
+# libsrt
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libsrt..." key
+fi
 
 # download libsrt
 curl --retry 5 -L -o srt-v1.4.1.tar.gz https://github.com/Haivision/srt/archive/v1.4.1.tar.gz
@@ -149,7 +159,9 @@ cd ../..
 
 
 # x264
-read -n1 -r -p "Press any key to build x264..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build x264..." key
+fi
 
 # download and prep x264
 git clone https://code.videolan.org/videolan/x264.git
@@ -174,7 +186,9 @@ cd ..
 
 
 # opus
-#read -n1 -r -p "Press any key to build opus..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build opus..." key
+fi
 
 # download opus
 curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.3.1.tar.gz
@@ -194,7 +208,9 @@ cd ..
 
 
 # zlib
-#read -n1 -r -p "Press any key to build zlib..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build zlib..." key
+fi
 
 # download zlib
 curl --retry 5 -L -O https://www.zlib.net/zlib-1.2.11.tar.gz
@@ -228,7 +244,9 @@ cd $WORKDIR
 
 
 # libpng
-#read -n1 -r -p "Press any key to build libpng..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libpng..." key
+fi
 
 # download libpng
 curl --retry 5 -L -o libpng-1.6.37.tar.gz https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
@@ -248,7 +266,9 @@ cd ..
 
 
 # libogg
-#read -n1 -r -p "Press any key to build libogg..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libogg..." key
+fi
 
 # download libogg
 curl --retry 5 -L -o ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz https://gitlab.xiph.org/xiph/ogg/-/archive/68ca3841567247ac1f7850801a164f58738d8df9/ogg-68ca3841567247ac1f7850801a164f58738d8df9.tar.gz
@@ -271,7 +291,9 @@ cd ../..
 
 
 # libvorbis
-#read -n1 -r -p "Press any key to build libvorbis..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libvorbis..." key
+fi
 
 # download libvorbis
 curl --retry 5 -L -O https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.6.tar.gz
@@ -291,7 +313,9 @@ cd ..
 
 
 # libvpx
-#read -n1 -r -p "Press any key to build libvpx..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build libvpx..." key
+fi
 
 # download libvpx
 curl --retry 5 -L -o libvpx-v1.8.1.tar.gz https://chromium.googlesource.com/webm/libvpx/+archive/v1.8.1.tar.gz
@@ -318,7 +342,9 @@ pkg-config --libs vpx
 
 
 # FFmpeg
-read -n1 -r -p "Press any key to build FFmpeg..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to build FFmpeg..." key
+fi
 
 # nv-codec-headers
 # download nv-codec-headers
@@ -346,7 +372,9 @@ cd ffmpeg
 patch -p1 < ../patch/ffmpeg/ffmpeg_flvdec.patch
 make clean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib" CPPFLAGS="-I$PREFIX/include -I$WORKDIR/pthread-win32" ./configure --enable-gpl --disable-doc --arch=x86_64 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="$PREFIX" --disable-postproc
-read -n1 -r -p "Press any key to continue building FFmpeg..." key
+if [ "$SKIP_PROMPTS" != true ]; then
+	read -n1 -r -p "Press any key to continue building FFmpeg..." key
+fi
 make -j$(nproc)
 make install
 cd ..

--- a/win64.sh
+++ b/win64.sh
@@ -10,6 +10,11 @@ mkdir lib
 cd ..
 mkdir -p win64/lib/pkgconfig
 
+# set build prefix
+WORKDIR=$PWD
+PREFIX=$PWD/win64
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+
 
 #---------------------------------
 
@@ -20,7 +25,7 @@ mkdir mbedtlsbuild
 mkdir mbedtlsbuild/win64
 cd mbedtlsbuild/win64
 rm -rf *
-cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
+cmake ../../mbedtls -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
 make -j$(nproc)
 x86_64-w64-mingw32-dlltool -z mbedtls.orig.def --export-all-symbols library/libmbedtls.dll
 x86_64-w64-mingw32-dlltool -z mbedcrypto.orig.def --export-all-symbols library/libmbedcrypto.dll
@@ -34,16 +39,16 @@ sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedx509.def
 x86_64-w64-mingw32-dlltool -z mbedtls.def --export-all-symbols library/libmbedtls.dll
 x86_64-w64-mingw32-dlltool -z mbedcrypto.def --export-all-symbols library/libmbedcrypto.dll
 x86_64-w64-mingw32-dlltool -z mbedx509.def --export-all-symbols library/libmbedx509.dll
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedtls.def -l /home/jim/packages/win64/bin/mbedtls.lib -D library/libmbedtls.dll
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedcrypto.def -l /home/jim/packages/win64/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedx509.def -l /home/jim/packages/win64/bin/mbedx509.lib -D library/libmbedx509.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedtls.def -l $PREFIX/bin/mbedtls.lib -D library/libmbedtls.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedcrypto.def -l $PREFIX/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d mbedx509.def -l $PREFIX/bin/mbedx509.lib -D library/libmbedx509.dll
 make install
 cd ../..
 
-mv win64/lib/*.dll win64/bin
+mv $PREFIX/lib/*.dll $PREFIX/bin
 
-cat > win64/lib/pkgconfig/mbedtls.pc <<EOF
-prefix=/home/jim/packages/win64
+cat > $PKG_CONFIG_PATH/mbedtls.pc <<EOF
+prefix=$PREFIX
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
@@ -57,8 +62,8 @@ Libs: -L\${libdir} -lmbedtls
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
-cat > win64/lib/pkgconfig/mbedcrypto.pc <<EOF
-prefix=/home/jim/packages/win64
+cat > $PKG_CONFIG_PATH/mbedcrypto.pc <<EOF
+prefix=$PREFIX
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
@@ -72,8 +77,8 @@ Libs: -L\${libdir} -lmbedcrypto
 Cflags: -I\${includedir} -I\${includedir}/mbedtls
 EOF
 
-cat > win64/lib/pkgconfig/mbedx509.pc <<EOF
-prefix=/home/jim/packages/win64
+cat > $PKG_CONFIG_PATH/mbedx509.pc <<EOF
+prefix=$PREFIX
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
@@ -94,8 +99,8 @@ EOF
 read -n1 -r -p "Press any key to build pthread-win32..." key
 
 cd pthread-win32
-make DESTROOT=/home/jim/packages/win64 CROSS=x86_64-w64-mingw32- realclean GC-small-static
-cp libpthreadGC2.a /home/jim/packages/win64/lib
+make DESTROOT=$PREFIX CROSS=x86_64-w64-mingw32- realclean GC-small-static
+cp libpthreadGC2.a $PREFIX/lib
 cd ..
 
 
@@ -108,7 +113,7 @@ mkdir srtbuild
 mkdir srtbuild/win64
 cd srtbuild/win64
 rm -rf *
-cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_CXX_FLAGS="-I/home/jim/packages/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="/home/jim/packages/win64/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="/home/jim/packages/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
+cmake ../../srt -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DUSE_ENCLIB=mbedtls -DENABLE_APPS=OFF -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_C_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_CXX_FLAGS="-I$WORKDIR/pthread-win32" -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug" -DPTHREAD_LIBRARY="$PREFIX/lib/libpthreadGC2.a" -DPTHREAD_INCLUDE_DIR="$WORKDIR/pthread-win32" -DUSE_OPENSSL_PC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel
 make -j$(nproc)
 x86_64-w64-mingw32-strip -w --keep-symbol=srt* libsrt.dll
 make install
@@ -122,15 +127,15 @@ read -n1 -r -p "Press any key to build x264..." key
 
 cd x264
 make clean
-LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=x86_64-w64-mingw32- --host=x86_64-pc-mingw32 --prefix="/home/jim/packages/win64"
+LDFLAGS="-static-libgcc" ./configure --enable-shared --disable-avs --disable-ffms --disable-gpac --disable-interlaced --disable-lavf --cross-prefix=x86_64-w64-mingw32- --host=x86_64-pc-mingw32 --prefix="$PREFIX"
 # make -j6 fprofiled VIDS="CITY_704x576_60_orig_01.yuv"
 make -j$(nproc)
 make install
-x86_64-w64-mingw32-dlltool -z /home/jim/packages/win64/bin/x264.orig.def --export-all-symbols /home/jim/packages/win64/bin/libx264-157.dll
-grep "EXPORTS\|x264" /home/jim/packages/win64/bin/x264.orig.def > /home/jim/packages/win64/bin/x264.def
-rm -f /home/jim/packages/win64/bin/x264.org.def
-sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" /home/jim/packages/win64/bin/x264.def
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d /home/jim/packages/win64/bin/x264.def -l /home/jim/packages/win64/bin/x264.lib -D /home/jim/win64/packages/bin/libx264-157.dll
+x86_64-w64-mingw32-dlltool -z $PREFIX/bin/x264.orig.def --export-all-symbols $PREFIX/bin/libx264-157.dll
+grep "EXPORTS\|x264" $PREFIX/bin/x264.orig.def > $PREFIX/bin/x264.def
+rm -f $PREFIX/bin/x264.org.def
+sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" $PREFIX/bin/x264.def
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d $PREFIX/bin/x264.def -l $PREFIX/bin/x264.lib -D $PREFIX/bin/libx264-157.dll
 cd ..
 
 
@@ -141,7 +146,7 @@ cd ..
 
 cd opus
 make clean
-LDFLAGS="-static-libgcc" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+LDFLAGS="-static-libgcc" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -154,13 +159,13 @@ cd ..
 
 cd zlib/build64
 make clean
-cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=/home/jim/packages/win64 -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
+cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -Wl,--strip-debug"
 make -j$(nproc)
 make install
-mv ../../win64/lib/libzlib.dll.a ../../win64/lib/libz.dll.a
-mv ../../win64/lib/libzlibstatic.a ../../win64/lib/libz.a
-cp ../win32/zlib.def /home/jim/packages/win64/bin
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d ../win32/zlib.def -l /home/jim/packages/win64/bin/zlib.lib -D /home/jim/win64/packages/bin/zlib.dll
+mv $PREFIX/lib/libzlib.dll.a $PREFIX/lib/libz.dll.a
+mv $PREFIX/lib/libzlibstatic.a $PREFIX/lib/libz.a
+cp ../win32/zlib.def $PREFIX/bin
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d ../win32/zlib.def -l $PREFIX/bin/zlib.lib -D $PREFIX/bin/zlib.dll
 cd ../..
 
 
@@ -171,7 +176,7 @@ cd ../..
 
 cd libpng
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib" CPPFLAGS="-I$PREFIX/include" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -184,7 +189,7 @@ cd ..
 
 cd libogg
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared
 make -j$(nproc)
 make install
 cd ..
@@ -197,7 +202,7 @@ cd ..
 
 cd libvorbis
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib -static-libgcc" CPPFLAGS="-I/home/jim/packages/win64/include" ./configure --host=x86_64-w64-mingw32 --prefix="/home/jim/packages/win64" --enable-shared --with-ogg="/home/jim/packages/win64"
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib -static-libgcc" CPPFLAGS="-I$PREFIX/include" ./configure --host=x86_64-w64-mingw32 --prefix="$PREFIX" --enable-shared --with-ogg="$PREFIX"
 make -j$(nproc)
 make install
 cd ..
@@ -210,10 +215,10 @@ cd ..
 
 cd libvpxbuild
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" CROSS=x86_64-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=/home/jim/packages/win64 --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86_64-win64-gcc
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CROSS=x86_64-w64-mingw32- LDFLAGS="-static-libgcc" ../libvpx/configure --prefix=$PREFIX --enable-vp8 --enable-vp9 --disable-docs --disable-examples --enable-shared --disable-static --enable-runtime-cpu-detect --enable-realtime-only --disable-install-bins --disable-install-docs --disable-unit-tests --target=x86_64-win64-gcc
 make -j$(nproc)
 make install
-x86_64-w64-mingw32-dlltool -m i386:x86-64 -d libvpx.def -l /home/jim/packages/win64/bin/vpx.lib -D /home/jim/win64/packages/bin/libvpx-1.dll
+x86_64-w64-mingw32-dlltool -m i386:x86-64 -d libvpx.def -l $PREFIX/bin/vpx.lib -D /home/jim/win64/packages/bin/libvpx-1.dll
 cd ..
 
 
@@ -223,16 +228,16 @@ cd ..
 read -n1 -r -p "Press any key to build FFmpeg..." key
 
 cd nv-codec-headers
-make PREFIX="/home/jim/packages/win64"
-make PREFIX="/home/jim/packages/win64" install
+make PREFIX="$PREFIX"
+make PREFIX="$PREFIX" install
 cd ..
 
-mkdir win64/include/AMF
-cp -a AMF/amf/public/include/* /home/jim/packages/win64/include/AMF
+mkdir $PREFIX/include/AMF
+cp -a AMF/amf/public/include/* $PREFIX/include/AMF
 
 cd ffmpeg
 make clean
-PKG_CONFIG_PATH="/home/jim/packages/win64/lib/pkgconfig" LDFLAGS="-L/home/jim/packages/win64/lib" CPPFLAGS="-I/home/jim/packages/win64/include -I/home/jim/packages/pthread-win32" ./configure --enable-gpl --disable-doc --arch=x86_64 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="/home/jim/packages/win64" --disable-postproc
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" LDFLAGS="-L$PREFIX/lib" CPPFLAGS="-I$PREFIX/include -I$WORKDIR/pthread-win32" ./configure --enable-gpl --disable-doc --arch=x86_64 --enable-shared --enable-nvenc --enable-amf --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libsrt --disable-debug --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32 --pkg-config=pkg-config --prefix="$PREFIX" --disable-postproc
 read -n1 -r -p "Press any key to continue building FFmpeg..." key
 make -j$(nproc)
 make install


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds scripts to cross-compile the Windows dependencies from Ubuntu.  Starting from Jim's build scripts, this gets us to a point where we can automate building the FFmpeg related dependencies on the obs-deps CI.

Obsoletes #1.

Some known issues:
* ~~The current deps package contains `zlib.dll` and `zlib.lib`.  This script generates `libzlib.dll` and `libzlib.lib`.  I couldn't figure out why this happens, so I assume Jim's scripts have a modification that I don't have here.~~
* This appears to _only_ be the FFmpeg related dependencies.  It does not build other dependencies such as cURL, FreeType, Lua/LuaJIT, Python, RNNoise, SWIG, Vulkan, or Websockets.  I'm guessing Jim builds those elsewhere.
* This doesn't follow the paradigms with GitHub workflows and script generation used by the macOS scripts.  I worked on this before that was merged, and I'd rather get this off my computer so it stops being neglected there.  If need be, it can be reworked later to fit those paradigms.

#### To-do
- [x] Fix naming of zlib DLL from libzlib.dll to zlib.dll as the current deps packages have
- [x] Moves files in `patches` to `patch` to avoid duplicate patch directories
- [ ] Address extra files produced here compared to current deps packages
- [ ] Build other deps not included here (perhaps in a follow-up PR rather than here)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Be more transparent about our dependencies.  Automate the process of updating and deploying our dependencies.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I used the deps built by these scripts as a replacement for the current Windows deps and they seemed to work fine.  Streaming and recording worked.  Admittedly, I did this testing a few months ago, so we should probably retest more thoroughly.

To test these:
1. Download and extract the deps artifact
2. Copy the artifact's `bin` and `include` folders over the existing corresponding deps (win32 or win64)
3. Clear the OBS build folder
4. Reset the additional_install_files folder (delete the folder and then `git restore` or `git reset`)
5. Run CMake for OBS as usual to configure and generate the project
6. Open the project and build it
7. Run OBS and record, stream, or perform other actions to test


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
