### PR TITLE
CI: Update Qt on macOS to 5.15.1

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -13,8 +13,8 @@ on:
       - master
 
 env:
-  MAC_QT_VERSION: '5.14.1'
-  MAC_QT_HASH: '6f17f488f512b39c2feb57d83a5e0a13dcef32999bea2e2a8f832f54a29badb8'
+  MAC_QT_VERSION: '5.15.1'
+  MAC_QT_HASH: '44da876057e21e1be42de31facd99be7d5f9f07893e1ea762359bcee0ef64ee9'
 
 jobs:
   macos64-main:


### PR DESCRIPTION
### Description
Updates Qt for macOS to v5.15.1

### Motivation and Context
While testing performance related issues on macOS a build using 5.15.1 was needed, so the necessary deps were built using this change.

This PR can be merged once the move to 5.15.1 is officially decided on.

### How Has This Been Tested?
* Qt 5.15.1 built and packaged locally
* OBS built with Qt 5.15.1 and tested successfully

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
