### PR TITLE
CI: Remove deprecated usage of `set-env` in Github Actions workflow

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get Current Date
         shell: bash
         id: get_date
-        run: echo ::set-env name=CURRENT_DATE::$(date +"%Y-%m-%d")
+        run: echo "CURRENT_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
       - name: Build environment setup
         shell: bash
         run: |
@@ -61,8 +61,8 @@ jobs:
           mkdir -p CI_BUILD/obsdeps/include
           mkdir -p CI_BUILD/obsdeps/lib
           mkdir -p CI_BUILD/obsdeps/share
-          echo ::set-env name=PKG_CONFIG_PATH::$PKG_CONFIG_PATH:/tmp/obsdeps/lib/pkgconfig
-          echo ::set-env name=PARALLELISM::$(sysctl -n hw.ncpu)
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/tmp/obsdeps/lib/pkgconfig" >> $GITHUB_ENV
+          echo "PARALLELISM=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
       - name: 'Restore swig from cache'
         id: swig-cache
         uses: actions/cache@v2
@@ -538,15 +538,15 @@ jobs:
       - name: Get Current Date
         shell: bash
         id: get_date
-        run: echo ::set-env name=CURRENT_DATE::$(date +"%Y-%m-%d")
+        run: echo "CURRENT_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
       - name: Build environment setup
         shell: bash
         run: |
           mkdir -p CI_BUILD/obsdeps/bin
           mkdir -p CI_BUILD/obsdeps/include
           mkdir -p CI_BUILD/obsdeps/lib
-          echo ::set-env name=PKG_CONFIG_PATH::$PKG_CONFIG_PATH:/tmp/obsdeps/lib/pkgconfig
-          echo ::set-env name=PARALLELISM::$(sysctl -n hw.ncpu)
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/tmp/obsdeps/lib/pkgconfig" >> $GITHUB_ENV
+          echo "PARALLELISM=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
       - name: 'Restore qt from cache'
         id: qt-cache
         uses: actions/cache@v2
@@ -620,7 +620,7 @@ jobs:
       - name: Get Current Date
         shell: bash
         id: get_date
-        run: echo ::set-env name=CURRENT_DATE::$(date +"%Y-%m-%d")
+        run: echo "CURRENT_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
       - name: 'Create Release'
         id: create_release
         uses: actions/create-release@v1

--- a/build_script_generator.py
+++ b/build_script_generator.py
@@ -39,7 +39,7 @@ def un_indent(match):
 
 def parse_macos_job(job_data, template, step_template, global_env):
 
-    find_setenv_pattern = re.compile('echo ::set-env name=(.+?)::(.+)')
+    find_setenv_pattern = re.compile('echo "(.+?)=(.+?)" >> \$GITHUB_ENV')
     find_env_pattern = re.compile('\\${{ env.(.+?) }}')
     find_heredoc_pattern = re.compile('<<(.+?) (.+?)?\n(.+?)\\1', re.MULTILINE|re.DOTALL)
     # current_path = os.path.realpath('.')


### PR DESCRIPTION
### Description
Changes usage of `set-env` in GitHub Actions with the new syntax to set environment variables for later steps.

### Motivation and Context
Github deprecates the `set-env` command: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

### How Has This Been Tested?
* Needs to be tested on CI

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
