### PR TITLE
CI: Fix x264 failing to build because of cache directory mismatch

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -253,7 +253,7 @@ jobs:
         env:
           CACHE_NAME: 'libx264-cache-rev2'
         with:
-          path: ${{ github.workspace }}/CI_BUILD/x264
+          path: ${{ github.workspace }}/CI_BUILD/x264-${{ env.LIBX264_VERSION }}
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.LIBX264_VERSION }}
       - name: 'Build dependency libx264'
         if: steps.libx264-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Description
Fixes x264 failing on CI for macOS due to a cache directory mismatch.

### Motivation and Context
Restore macOS builds finishing.

### How Has This Been Tested?
* Needs to be tested on CI

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
