### PR TITLE
Update build scripts for macOS to restore homebrew env after building

### DIFF
--- a/build_script_generator.py
+++ b/build_script_generator.py
@@ -81,6 +81,7 @@ def parse_macos_job(job_data, template, step_template, global_env):
             for match in matches:
                 environment.update({match[0]: match[1]})
 
+            script_content = script_content.replace('curl --retry 5', 'curl --progress-bar --retry 5')
             script_content = find_setenv_pattern.sub('', script_content)
             script_content = script_content.replace('${{ github.workspace }}', current_path)
             script_content = find_env_pattern.sub('${\\1}', script_content)

--- a/templates/build-script-macos.tpl
+++ b/templates/build-script-macos.tpl
@@ -38,7 +38,7 @@ ensure_dir() {{
 }}
 
 cleanup() {{
-    :
+    restore_brews
 }}
 
 mkdir() {{
@@ -53,12 +53,32 @@ caught_error() {{
     exit 1
 }}
 
+restore_brews() {{
+    if [ -d /usr/local/opt/xz ]; then
+      brew link xz
+    fi
+
+    if [ -d /usr/local/opt/zstd ]; then
+      brew link zstd
+    fi
+
+    if [ -d /usr/local/opt/libtiff ]; then
+      brew link libtiff
+    fi
+
+    if [ -d /usr/local/opt/webp ]; then
+      brew link webp
+    fi
+}}
+
 {build_steps}
 
 obs-deps-build-main() {{
     ensure_dir {workspace}
 
 {call_build_steps}
+
+    restore_brews
 
     hr "All Done"
 }}


### PR DESCRIPTION
### Description
This update adds an additional function to restore homebrew formulas once the script finishes. When building locally, certain pre-existing formulas need to be unlinked to avoid the deps being linked against them. Once the script is done, the original system state should be restored.

### Motivation and Context
Reduce friction/impact of local build scripts on system configurations.

### How Has This Been Tested?
* Tested locally

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
