### PR TITLE
CI: Fix caching for Qt builds on macOS

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -551,9 +551,9 @@ jobs:
         id: qt-cache
         uses: actions/cache@v2
         env:
-          CACHE_NAME: 'qt-build-cache-rev3'
+          CACHE_NAME: 'qt-build-cache-rev5'
         with:
-          path: /tmp/obsdeps
+          path: ${{ github.workspace }}/CI_BUILD/qt-everywhere-src-${{ env.MAC_QT_VERSION }}/build
           key: ${{ runner.os }}-deps-${{ env.CACHE_NAME }}-${{ env.MAC_QT_VERSION }}
       - name: 'Build dependency Qt'
         if: steps.qt-cache.outputs.cache-hit != 'true'
@@ -594,6 +594,14 @@ jobs:
             -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
             -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns
           make -j${{ env.PARALLELISM }}
+
+          if [ -d /usr/local/opt/zstd ]; then
+            brew link zstd
+          fi
+      - name: 'Install dependency Qt'
+        shell: bash
+        working-directory: ${{ github.workspace }}/CI_BUILD/qt-everywhere-src-${{ env.MAC_QT_VERSION }}/build
+        run: |
           make install
       - name: Package dependencies
         if: success()


### PR DESCRIPTION
### Description
Fixes caching of Qt build results.

### Motivation and Context
To avoid additional pre-existing Qt dependencies to be linked when building for distribution, `zstd` is unlinked before building Qt. Unfortunately `zstd` is required by the Github caching actions.

Linking `zstd` after successfully building Qt will restore caching functionality.

### How Has This Been Tested?
* Tested in my own fork

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
