### PR TITLE
CI: Fix brotli dependency on freetype

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -507,7 +507,7 @@ jobs:
         id: libfreetype-cache
         uses: actions/cache@v2.1.2
         env:
-          CACHE_NAME: 'libfreetype-cache-rev2'
+          CACHE_NAME: 'libfreetype-cache-rev3'
         with:
           path: ${{ github.workspace }}/CI_BUILD/freetype-${{ env.LIBFREETYPE_VERSION }}
           key: ${{ runner.os }}-deps-${{ env.CACHE_NAME }}-${{ env.LIBFREETYPE_VERSION }}
@@ -522,7 +522,7 @@ jobs:
           cd freetype-${{ env.LIBFREETYPE_VERSION }}
           mkdir build
           cd build
-          ../configure --enable-shared --disable-static --prefix="/tmp/obsdeps" --without-harfbuzz
+          ../configure --enable-shared --disable-static --prefix="/tmp/obsdeps" --without-harfbuzz --without-brotli
           make -j${{ env.PARALLELISM }}
       - name: 'Install dependency libfreetype'
         shell: bash

--- a/.github/workflows/create_scripts.yml
+++ b/.github/workflows/create_scripts.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '.github/workflows/build_deps.yml'
       - '.github/workflows/create_scripts.yml'
+      - '!build-script-macos-01.sh'
+      - '!build-script-macos-02.sh'
     branches:
       - master
 
@@ -48,7 +50,7 @@ jobs:
           echo "  + Build scripts successfully generated"
 
           if git diff --quiet; then
-            echo "  + No script changes changes to commit";
+            echo "  + No script changes to commit";
             exit 0;
           fi
 
@@ -58,6 +60,7 @@ jobs:
 
           git config user.name "Github Actions CI"
           git config user.email "${{ github.event.pusher.email }}"
+          git config pull.rebase false
 
           git add build-script-*
           git pull

--- a/utils/build_script_generator.py
+++ b/utils/build_script_generator.py
@@ -39,9 +39,10 @@ def un_indent(match):
 
 def parse_macos_job(job_data, template, step_template, global_env):
 
-    find_setenv_pattern = re.compile('echo "(.+?)=(.+?)" >> \$GITHUB_ENV')
+    find_setenv_pattern = re.compile('echo "(.+?)=(.+?)" >> \\$GITHUB_ENV')
     find_env_pattern = re.compile('\\${{ env.(.+?) }}')
     find_heredoc_pattern = re.compile('<<(.+?) (.+?)?\n(.+?)\\1', re.MULTILINE|re.DOTALL)
+    find_title_pattern = re.compile('[^a-z^0-9]')
     # current_path = os.path.realpath('.')
     current_path = "${BASE_DIR}"
     environment = global_env
@@ -54,8 +55,9 @@ def parse_macos_job(job_data, template, step_template, global_env):
 
     for i, step in enumerate(steps, start=1):
 
-        step_id = str(uuid.uuid4())
         step_name = step.get('name', '')
+        safe_step_name = re.sub(find_title_pattern, '_', step_name.lower())
+        step_id = f"{i:02d}_{safe_step_name}"
         has_action = step.get('uses', '')
         step_shell = step.get('shell', '')
         script_content = step.get('run', '')


### PR DESCRIPTION
### Description
Fixes unexpected dependency on brotli introduced by freetype's support for WOFF fonts. This lead to brotli being linked from Homebrew inside the deps artifact which cannot be found when bundling OBS.

Also introduces "stable" function naming in the build scripts. The script generator workflow was diffing old and new scripts and as a `uuid` was used _any_ invocation of the script generated a diff and the generator ran even though it didn't have to (this also generates unnecessary script generation runs on forks which makes rebasing a pain).

### Motivation and Context
Enables building/bundling of OBS without missing dependencies.

### How Has This Been Tested?
* Freetype building tested locally (confirmed brotli was excluded)
* Python script generator tested

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
