### PR TITLE
CI: Update azure pipelines to use auto-generated scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,13 +7,15 @@ jobs:
   steps:
   - script: git submodule update --init --recursive
     displayName: 'Checkout Submodules'
-  - script: ./osx-install-tools.sh
-    displayName: 'Install Tools'
-  - script: ./build-package-deps-osx.sh
-    displayName: 'Build And Package'
-
+  - bash: |
+      python3 -m pip install pyyaml
+      python3 ./utils/build_script_generator.py ./.github/workflows/build_deps.yml
+      echo "  + Build scripts successfully generated"
+    displayName: Generate build scripts
+  - script: TERM="" bash ./build-script-macos-01.sh
+    displayName: 'Build dependencies'
   - task: PublishBuildArtifacts@1
     condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
-      pathtoPublish: './osx'
+      pathtoPublish: './macos'
       artifactName: osx-deps


### PR DESCRIPTION
### Description
Updates azure pipelines workflows for macOS to use scripts generated from Github CI workflows. This allows Azure to always stay up to date with Github's workflow.

### Motivation and Context
Remove burden to update two workflows at the same time and also keeps dependencies built on azure updated.

### How Has This Been Tested?
Needs to be tested on Azure CI directly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
