### PR TITLE
CI: Update x264 with new stack realignment

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -37,8 +37,8 @@ jobs:
       LIBVPX_HASH: 'd279c10e4b9316bf11a570ba16c3d55791e1ad6faa4404c67422eb631782c80a'
       LIBJANSSON_VERSION: '2.13.1'
       LIBJANSSON_HASH: 'f4f377da17b10201a60c1108613e78ee15df6b12016b116b6de42209f47a474f'
-      LIBX264_VERSION: 'r3018'
-      LIBX264_HASH: 'db0d417728460c647ed4a847222a535b00d3dbcb'
+      LIBX264_VERSION: 'r3027'
+      LIBX264_HASH: '4121277b40a667665d4eea1726aefdc55d12d110'
       LIBMBEDTLS_VERSION: '2.24.0'
       LIBMEDTLS_HASH: 'b5a779b5f36d5fc4cba55faa410685f89128702423ad07b36c5665441a06a5f3'
       LIBSRT_VERSION: '1.4.2'
@@ -202,18 +202,25 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/CI_BUILD
         run: |
-          CLANG_BUILD_VERSION="$(clang --version | sed -En 's/.+\clang-([0-9]+).+/\1/p')"
-          if [ "${CLANG_BUILD_VERSION}" -ge 1010 ]; then
-            CONFIG_EXTRA="-fno-stack-check"
+          MACOS_VERSION="$(sw_vers -productVersion)"
+          MACOS_MAJOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 1)"
+          MACOS_MINOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 2)"
+          if [ "${MACOS_MAJOR}" -eq 10 ] && [ "${MACOS_MINOR}" -le 12 ]; then
+            brew install gcc || true
+            CC="/usr/local/bin/gcc"
+            LD="/usr/local/bin/gcc"
+            CXX=="/usr/local/bin/g++"
           fi
           mkdir -p x264-${{ env.LIBX264_VERSION }}
           cd ./x264-${{ env.LIBX264_VERSION }}
           ${{ github.workspace }}/utils/github_fetch mirror x264 "${{ env.LIBX264_HASH }}"
-          ${{ github.workspace }}/utils/apply_patch "https://github.com/mirror/x264/commit/eb95c2965299ba5b8598e2388d71b02e23c9fba7.patch?full_index=1" "a7df326ced312c3aa2ae4c463ab08e43961b2dea63b7b365874fb0d59622e63d"
           mkdir build
           cd ./build
-          ../configure --extra-ldflags="-mmacosx-version-min=${{ env.MACOSX_DEPLOYMENT_TARGET }}" ${CONFIG_EXTRA} --enable-static --disable-lsmash --disable-swscale --disable-ffms --enable-strip --prefix="/tmp/obsdeps"
+          ../configure --extra-ldflags="-mmacosx-version-min=${{ env.MACOSX_DEPLOYMENT_TARGET }}" --enable-static --disable-lsmash --disable-swscale --disable-ffms --enable-strip --prefix="/tmp/obsdeps"
           make -j${{ env.PARALLELISM }}
+          unset CC
+          unset LD
+          unset CXX
       - name: 'Install dependency libx264'
         shell: bash
         working-directory: ${{ github.workspace }}/CI_BUILD/x264-${{ env.LIBX264_VERSION }}/build
@@ -376,8 +383,20 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/CI_BUILD/x264-${{ env.LIBX264_VERSION }}/build
         run: |
-          ../configure --extra-ldflags="-mmacosx-version-min=${{ env.MACOSX_DEPLOYMENT_TARGET }}" ${CONFIG_EXTRA} --enable-shared  --disable-lsmash --disable-swscale --disable-ffms --enable-strip --libdir="/tmp/obsdeps/bin" --prefix="/tmp/obsdeps"
+          MACOS_VERSION="$(sw_vers -productVersion)"
+          MACOS_MAJOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 1)"
+          MACOS_MINOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 2)"
+          if [ "${MACOS_MAJOR}" -eq 10 ] && [ "${MACOS_MINOR}" -le 12 ]; then
+            brew install gcc || true
+            CC="/usr/local/bin/gcc"
+            LD="/usr/local/bin/gcc"
+            CXX=="/usr/local/bin/g++"
+          fi
+          ../configure --extra-ldflags="-mmacosx-version-min=${{ env.MACOSX_DEPLOYMENT_TARGET }}" --enable-shared  --disable-lsmash --disable-swscale --disable-ffms --enable-strip --libdir="/tmp/obsdeps/bin" --prefix="/tmp/obsdeps"
           make -j${{ env.PARALLELISM }}
+          unset CC
+          unset LD
+          unset CXX
       - name: 'Install dependency libx264 (dylib)'
         shell: bash
         working-directory: ${{ github.workspace }}/CI_BUILD/x264-${{ env.LIBX264_VERSION }}/build


### PR DESCRIPTION
### Description
Update x264 to newest release.

### Motivation and Context
Since x264 has moved their stack realignment from asm to C, an additional workaround for High Sierra (10.13) is needed as its clang is too old to support this feature.

See also: https://code.videolan.org/videolan/x264/-/commit/b5bc5d69c580429ff716bafcd43655e855c31b02

### How Has This Been Tested?
* x264 built locally

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
