### PR TITLE
CI: Update to Qt 5.15.2 for macOS

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -13,8 +13,8 @@ on:
       - master
 
 env:
-  MAC_QT_VERSION: '5.14.1'
-  MAC_QT_HASH: '6f17f488f512b39c2feb57d83a5e0a13dcef32999bea2e2a8f832f54a29badb8'
+  MAC_QT_VERSION: '5.15.2'
+  MAC_QT_HASH: '3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240'
 
 jobs:
   macos64-main:
@@ -626,7 +626,9 @@ jobs:
               ${{ github.workspace }}/utils/apply_patch "https://github.com/qt/qtbase/commit/8e5d6b422136dcca51f2c18fddcf28016f5ab99a.patch?full_index=1" "943e5e69160a39bcda0e88289b27c95732db1a195f0cf211601f10f1a067e608"
               cd ..
           else
-              cd qt-everywhere-src-${{ env.MAC_QT_VERSION }}
+              cd qt-everywhere-src-${{ env.MAC_QT_VERSION }}/qtbase
+              ${{ github.workspace }}/utils/apply_patch "https://gist.githubusercontent.com/PatTheMav/e296886af7485d8cc85857ea4e99706b/raw/efa9f697c3b6332eeb58ce49aaccec2bb4a1674b/obs-issue-3799-qt.patch" "234ee6b21a008a233382c872ac097707ce83e401d3bcd5f1b244c09c0817f3aa"
+              cd ..
           fi
           mkdir build
           cd build


### PR DESCRIPTION
### Description
Updates Qt to 5.15.2 as part of prebuilt dependencies.

### Motivation and Context
Prepares for milestone 26.1 as discussed in https://github.com/obsproject/obs-studio/issues/3752.

### How Has This Been Tested?
* Qt built locally
* OBS built with most recent deps and Qt
* OBS launched
* Checked VirtualCamera
* Checked Recording
* Checked Streaming (local SRT server)

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
