### PR TITLE
CI: Fix incompatibilities with macOS 10.13

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -96,7 +96,7 @@ jobs:
         id: ffmpeg-deps-cache
         uses: actions/cache@v2.1.2
         env:
-          CACHE_NAME: 'ffmpeg-deps'
+          CACHE_NAME: 'ffmpeg-deps_r2'
         with:
           path: |
             ${{ github.workspace }}/CI_BUILD/libpng-${{ env.LIBPNG_VERSION }}
@@ -205,7 +205,7 @@ jobs:
           MACOS_VERSION="$(sw_vers -productVersion)"
           MACOS_MAJOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 1)"
           MACOS_MINOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 2)"
-          if [ "${MACOS_MAJOR}" -eq 10 ] && [ "${MACOS_MINOR}" -le 12 ]; then
+          if [ "${MACOS_MAJOR}" -eq 10 ] && [ "${MACOS_MINOR}" -le 13 ]; then
             brew install gcc || true
             CC="/usr/local/bin/gcc"
             LD="/usr/local/bin/gcc"
@@ -255,7 +255,7 @@ jobs:
           mkdir build
           cd ./build
           ../configure --disable-shared --disable-dependency-tracking --disable-debug --enable-nasm --prefix="/tmp/obsdeps"
-          make -j${{ env.PARALLELISM }}
+          MACOSX_DEPLOYMENT_TARGET="10.13" make -j${{ env.PARALLELISM }}
       - name: 'Install dependency liblame'
         shell: bash
         working-directory: ${{ github.workspace }}/CI_BUILD/lame-${{ env.LIBLAME_VERSION }}/build
@@ -385,7 +385,7 @@ jobs:
           MACOS_VERSION="$(sw_vers -productVersion)"
           MACOS_MAJOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 1)"
           MACOS_MINOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 2)"
-          if [ "${MACOS_MAJOR}" -eq 10 ] && [ "${MACOS_MINOR}" -le 12 ]; then
+          if [ "${MACOS_MAJOR}" -eq 10 ] && [ "${MACOS_MINOR}" -le 13 ]; then
             brew install gcc || true
             CC="/usr/local/bin/gcc"
             LD="/usr/local/bin/gcc"


### PR DESCRIPTION
### Description
Fixes `lame-mp3` using a dependency symbol only available on macOS 10.14+.

### Motivation and Context
For some reason `lame-mp3` doesn't recognise the `MACOSX_DEPLOYMENT_TARGET` environment variable set by the workflow and requires it to be set explicitly when invoking `make`.

*Note:* This might mean that setting it globally doesn't work or it could just mean that lame's build process doesn't pick it up correctly. We should be on the lookout for more incompatibilities.

### How Has This Been Tested?
Dependencies were built locally and checked to not contain the offending `____chkstk_darwin` symbol.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
