### PR TITLE
CI: Fix missing cache revision for libjansson

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -467,7 +467,7 @@ jobs:
         id: libjansson-cache
         uses: actions/cache@v2.1.2
         env:
-          CACHE_NAME: 'libjansson'
+          CACHE_NAME: 'libjansson-rev2'
         with:
           path: ${{ github.workspace }}/CI_BUILD/jansson-${{ env.LIBJANSSON_VERSION }}
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.LIBJANSSON_VERSION }}


### PR DESCRIPTION
### Description

Fixes libjansson being packaged with outdated dylib ID.

### Motivation and Context
In https://github.com/obsproject/obs-deps/commit/89367e2ed35b4ae2336dfeb4aea60da291623ea5 libjansson was fixed to be placed in `/lib/` but because the cache revision was not changed the final release packaged outdated libjansson with a wrong glib ID.

### How Has This Been Tested?
Needs to be tested on CI as it's dependent on a cache-entry miss for updated libjansson specs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
