### PR TITLE
CI: Build OBS dependencies for Apple Silicon Macs

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -185,19 +185,32 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/CI_BUILD
         run: |
-          ${{ github.workspace }}/utils/safe_fetch "https://github.com/webmproject/libvpx/archive/v${{ env.LIBVPX_VERSION }}.tar.gz" "${{ env.LIBVPX_HASH }}"
-          mkdir -p ./libvpx-v${{ env.LIBVPX_VERSION }}
-          tar -xf v${{ env.LIBVPX_VERSION }}.tar.gz
+          # Note: libvpx 1.9.0, which is the most current release when this was written,
+          # doesn't support building for arm64 on macOS, but the latest development code
+          # supports building for arm64 on macOS. So, on Apple Silicon Macs, we have to clone
+          # the latest code instead of downloading an archive. This can be revised when the
+          # next version of libvpx comes out.
+          if [ `arch` = "arm64" ]; then
+            git clone "https://chromium.googlesource.com/webm/libvpx" libvpx-${{ env.LIBVPX_VERSION }}
+          else
+            ${{ github.workspace }}/utils/safe_fetch "https://github.com/webmproject/libvpx/archive/v${{ env.LIBVPX_VERSION }}.tar.gz" "${{ env.LIBVPX_HASH }}"
+            mkdir -p ./libvpx-v${{ env.LIBVPX_VERSION }}
+            tar -xf v${{ env.LIBVPX_VERSION }}.tar.gz
+          fi
           cd ./libvpx-${{ env.LIBVPX_VERSION }}
           mkdir -p build
           cd ./build
-          # Assumption is that macOS has switched to proper major version numbering with Big Sur
-          if [ $(echo "${{ env.MACOSX_DEPLOYMENT_TARGET }}" | cut -d "." -f 1) -lt 11 ]; then
-            VPX_TARGET="$(($(echo ${{ env.MACOSX_DEPLOYMENT_TARGET }} | cut -d "." -f 2)+4))";
+          if [ `arch` = "arm64" ]; then
+            ../configure --target="arm64-darwin20-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
           else
-            VPX_TARGET="$(($(echo ${{ env.MACOSX_DEPLOYMENT_TARGET }} | cut -d "." -f 1)+9))";
+            # Assumption is that macOS has switched to proper major version numbering with Big Sur
+            if [ $(echo "${{ env.MACOSX_DEPLOYMENT_TARGET }}" | cut -d "." -f 1) -lt 11 ]; then
+              VPX_TARGET="$(($(echo ${{ env.MACOSX_DEPLOYMENT_TARGET }} | cut -d "." -f 2)+4))";
+            else
+              VPX_TARGET="$(($(echo ${{ env.MACOSX_DEPLOYMENT_TARGET }} | cut -d "." -f 1)+9))";
+            fi
+            ../configure --target="x86_64-darwin$VPX_TARGET-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
           fi
-          ../configure --target="x86_64-darwin$VPX_TARGET-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
           make -j${{ env.PARALLELISM }}
       - name: 'Install dependency libvpx'
         shell: bash
@@ -671,7 +684,8 @@ jobs:
             -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects \
             -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtspeech \
             -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
-            -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns
+            -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns \
+            QMAKE_APPLE_DEVICE_ARCHS=`arch`
           make -j${{ env.PARALLELISM }}
           make install
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scripts to build and package dependencies for OBS on CI
 |libogg|[xiph.org](https://downloads.xiph.org/releases/ogg/libogg-1.3.4.tar.gz)|1.3.4|
 |librnnoise|[90ec41e](https://github.com/xiph/rnnoise/commit/90ec41ef659fd82cfec2103e9bb7fc235e9ea66c)||
 |libvorbis|[xiph.org](https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz)|1.3.7|
-|libvpx|[Github](https://github.com/webmproject/libvpx/archive/v1.9.0.tar.gz)|1.9.0|
+|libvpx|[Github](https://github.com/webmproject/libvpx/archive/v1.9.0.tar.gz)|1.9.0 (x86_64), latest master branch (arm64)|
 |libjansson|[Petri Lehtinen](https://digip.org/jansson/releases/jansson-2.13.1.tar.gz)|2.13.1|
 |libx264|[db0d417](https://github.com/mirror/x264/commit/db0d417728460c647ed4a847222a535b00d3dbcb)|r3018|
 |libmbedtls|[Github](https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.24.0.tar.gz)|2.24.0|

--- a/build-script-macos-01.sh
+++ b/build-script-macos-01.sh
@@ -49,11 +49,7 @@ export PCRE_VERSION="8.44"
 export PCRE_HASH="19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
 export SWIG_VERSION="4.0.2"
 export SWIG_HASH="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-if [ `arch` = "arm64" ]; then
-    export MACOSX_DEPLOYMENT_TARGET="11.0"
-else
-    export MACOSX_DEPLOYMENT_TARGET="10.13"
-fi
+export MACOSX_DEPLOYMENT_TARGET="10.13"
 export FFMPEG_REVISION="06"
 export PATH="/usr/local/opt/ccache/libexec:${PATH}"
 export CURRENT_DATE="$(date +"%Y-%m-%d")"
@@ -275,27 +271,25 @@ build_14_build_dependency_libvpx() {
     # the latest code instead of downloading an archive. This can be revised when the
     # next version of libvpx comes out.
     if [ `arch` = "arm64" ]; then
-        git clone "https://chromium.googlesource.com/webm/libvpx"
-        cd ./libvpx
+      git clone "https://chromium.googlesource.com/webm/libvpx" libvpx-${LIBVPX_VERSION}
     else
-        ${BASE_DIR}/utils/safe_fetch "https://github.com/webmproject/libvpx/archive/v${LIBVPX_VERSION}.tar.gz" "${LIBVPX_HASH}"
-        mkdir -p ./libvpx-v${LIBVPX_VERSION}
-        tar -xf v${LIBVPX_VERSION}.tar.gz
-        cd ./libvpx-${LIBVPX_VERSION}
+      ${BASE_DIR}/utils/safe_fetch "https://github.com/webmproject/libvpx/archive/v${LIBVPX_VERSION}.tar.gz" "${LIBVPX_HASH}"
+      mkdir -p ./libvpx-v${LIBVPX_VERSION}
+      tar -xf v${LIBVPX_VERSION}.tar.gz
     fi
-
+    cd ./libvpx-${LIBVPX_VERSION}
     mkdir -p build
     cd ./build
     if [ `arch` = "arm64" ]; then
-        ../configure --target="arm64-darwin20-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
+      ../configure --target="arm64-darwin20-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
     else
-        # Assumption is that macOS has switched to proper major version numbering with Big Sur
-        if [ $(echo "${MACOSX_DEPLOYMENT_TARGET}" | cut -d "." -f 1) -lt 11 ]; then
-            VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 2)+4))";
-        else
-            VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 1)+9))";
-        fi
-        ../configure --target="x86_64-darwin$VPX_TARGET-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
+      # Assumption is that macOS has switched to proper major version numbering with Big Sur
+      if [ $(echo "${MACOSX_DEPLOYMENT_TARGET}" | cut -d "." -f 1) -lt 11 ]; then
+          VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 2)+4))";
+      else
+          VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 1)+9))";
+      fi
+      ../configure --target="x86_64-darwin$VPX_TARGET-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
     fi
     make -j${PARALLELISM}
 }
@@ -304,14 +298,8 @@ build_14_build_dependency_libvpx() {
 build_15_install_dependency_libvpx() {
     step "Install dependency libvpx"
     trap "caught_error 'Install dependency libvpx'" ERR
-    # See the comment in build_14_build_dependency_libvpx() above. When a future source
-    # distribution of libvpx supports Apple Silicon, then this if statement can be
-    # removed as well.
-    if [ `arch` = "arm64" ]; then
-        ensure_dir ${BASE_DIR}/CI_BUILD/libvpx/build
-    else
-        ensure_dir ${BASE_DIR}/CI_BUILD/libvpx-${LIBVPX_VERSION}/build
-    fi
+    ensure_dir ${BASE_DIR}/CI_BUILD/libvpx-1.9.0/build
+
     make install
 }
 

--- a/build-script-macos-01.sh
+++ b/build-script-macos-01.sh
@@ -49,7 +49,11 @@ export PCRE_VERSION="8.44"
 export PCRE_HASH="19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
 export SWIG_VERSION="4.0.2"
 export SWIG_HASH="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-export MACOSX_DEPLOYMENT_TARGET="10.13"
+if [ `arch` = "arm64" ]; then
+    export MACOSX_DEPLOYMENT_TARGET="11.0"
+else
+    export MACOSX_DEPLOYMENT_TARGET="10.13"
+fi
 export FFMPEG_REVISION="06"
 export PATH="/usr/local/opt/ccache/libexec:${PATH}"
 export CURRENT_DATE="$(date +"%Y-%m-%d")"
@@ -265,19 +269,34 @@ build_14_build_dependency_libvpx() {
     trap "caught_error 'Build dependency libvpx'" ERR
     ensure_dir ${BASE_DIR}/CI_BUILD
 
-    ${BASE_DIR}/utils/safe_fetch "https://github.com/webmproject/libvpx/archive/v${LIBVPX_VERSION}.tar.gz" "${LIBVPX_HASH}"
-    mkdir -p ./libvpx-v${LIBVPX_VERSION}
-    tar -xf v${LIBVPX_VERSION}.tar.gz
-    cd ./libvpx-${LIBVPX_VERSION}
+    # Note: libvpx 1.9.0, which is the most current release when this was written,
+    # doesn't support building for arm64 on macOS, but the latest development code
+    # supports building for arm64 on macOS. So, on Apple Silicon Macs, we have to clone
+    # the latest code instead of downloading an archive. This can be revised when the
+    # next version of libvpx comes out.
+    if [ `arch` = "arm64" ]; then
+        git clone "https://chromium.googlesource.com/webm/libvpx"
+        cd ./libvpx
+    else
+        ${BASE_DIR}/utils/safe_fetch "https://github.com/webmproject/libvpx/archive/v${LIBVPX_VERSION}.tar.gz" "${LIBVPX_HASH}"
+        mkdir -p ./libvpx-v${LIBVPX_VERSION}
+        tar -xf v${LIBVPX_VERSION}.tar.gz
+        cd ./libvpx-${LIBVPX_VERSION}
+    fi
+
     mkdir -p build
     cd ./build
-    # Assumption is that macOS has switched to proper major version numbering with Big Sur
-    if [ $(echo "${MACOSX_DEPLOYMENT_TARGET}" | cut -d "." -f 1) -lt 11 ]; then
-      VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 2)+4))";
+    if [ `arch` = "arm64" ]; then
+        ../configure --target="arm64-darwin20-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
     else
-      VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 1)+9))";
+        # Assumption is that macOS has switched to proper major version numbering with Big Sur
+        if [ $(echo "${MACOSX_DEPLOYMENT_TARGET}" | cut -d "." -f 1) -lt 11 ]; then
+            VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 2)+4))";
+        else
+            VPX_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 1)+9))";
+        fi
+        ../configure --target="x86_64-darwin$VPX_TARGET-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
     fi
-    ../configure --target="x86_64-darwin$VPX_TARGET-gcc" --disable-shared --disable-examples --disable-unit-tests --enable-pic --enable-vp9-highbitdepth --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
     make -j${PARALLELISM}
 }
 
@@ -285,8 +304,14 @@ build_14_build_dependency_libvpx() {
 build_15_install_dependency_libvpx() {
     step "Install dependency libvpx"
     trap "caught_error 'Install dependency libvpx'" ERR
-    ensure_dir ${BASE_DIR}/CI_BUILD/libvpx-1.9.0/build
-
+    # See the comment in build_14_build_dependency_libvpx() above. When a future source
+    # distribution of libvpx supports Apple Silicon, then this if statement can be
+    # removed as well.
+    if [ `arch` = "arm64" ]; then
+        ensure_dir ${BASE_DIR}/CI_BUILD/libvpx/build
+    else
+        ensure_dir ${BASE_DIR}/CI_BUILD/libvpx-${LIBVPX_VERSION}/build
+    fi
     make install
 }
 

--- a/build-script-macos-02.sh
+++ b/build-script-macos-02.sh
@@ -49,7 +49,11 @@ export PCRE_VERSION="8.44"
 export PCRE_HASH="19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
 export SWIG_VERSION="4.0.2"
 export SWIG_HASH="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-export MACOSX_DEPLOYMENT_TARGET="10.13"
+if [ `arch` = "arm64" ]; then
+    export MACOSX_DEPLOYMENT_TARGET="11.0"
+else
+    export MACOSX_DEPLOYMENT_TARGET="10.13"
+fi
 export FFMPEG_REVISION="06"
 export PATH="/usr/local/opt/ccache/libexec:${PATH}"
 export CURRENT_DATE="$(date +"%Y-%m-%d")"
@@ -199,7 +203,8 @@ build_06_build_dependency_qt() {
       -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects \
       -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtspeech \
       -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
-      -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns
+      -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns \
+      QMAKE_APPLE_DEVICE_ARCHS=`arch`
     make -j${PARALLELISM}
     make install
     

--- a/build-script-macos-02.sh
+++ b/build-script-macos-02.sh
@@ -49,11 +49,7 @@ export PCRE_VERSION="8.44"
 export PCRE_HASH="19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
 export SWIG_VERSION="4.0.2"
 export SWIG_HASH="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-if [ `arch` = "arm64" ]; then
-    export MACOSX_DEPLOYMENT_TARGET="11.0"
-else
-    export MACOSX_DEPLOYMENT_TARGET="10.13"
-fi
+export MACOSX_DEPLOYMENT_TARGET="10.13"
 export FFMPEG_REVISION="06"
 export PATH="/usr/local/opt/ccache/libexec:${PATH}"
 export CURRENT_DATE="$(date +"%Y-%m-%d")"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change updates the build scripts so that, when they are run on an Apple Silicon Mac, they will build the dependencies for an Apple Silicon Mac.

All of the dependencies build without any changes, except for libvpx and Qt. libvpx 1.9.0 does not support building for arm64 on macOS, but the master branch code does, so for the time being, we have to clone and then build from the master branch. Qt needs to be coerced to build for arm64 using the variable QMAKE_APPLE_DEVICE_ARCHS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Apple is switching CPU architectures. In a few years, they won't be shipping or supporting Intel Macs anymore, so it's time to start producing a build for the new Apple Silicon Macs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested my changes on my Apple Development Platform running Xcode 12.4. Both scripts complete successfully, and running `lipo -info` on the resulting binaries indicate that they are built for arm64.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
