### PR TITLE
CI: Use 'uname -m' for QMAKE_APPLE_DEVICE_ARCHS

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -685,7 +685,7 @@ jobs:
             -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtspeech \
             -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
             -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns \
-            QMAKE_APPLE_DEVICE_ARCHS=`arch`
+            QMAKE_APPLE_DEVICE_ARCHS=$(uname -m)
           make -j${{ env.PARALLELISM }}
           make install
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Use `uname -m` instead of `arch` to set `QMAKE_APPLE_DEVICE_ARCHS` when building Qt.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Currently, `QMAKE_APPLE_DEVICE_ARCHS` is set using `arch`, which returns `i386` for Intel-based machines. `QMAKE_APPLE_DEVICE_ARCHS` expects `x86_64`, which `uname -m` returns. Both `arch` and `uname -m` return `arm64` on Apple M1 machines.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

With `QMAKE_APPLE_DEVICE_ARCHS` being set by `arch` (result `i386`), Qt 5.15.2 failed to build on my 2018 Mac Mini (6-core) running macOS 11.2. Setting `QMAKE_APPLE_DEVICE_ARCHS` using `uname -m` (result `x86_64`) resolved this issue. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
