### PR TITLE
CI: Fix caught_error function. Quote paths in ensure_dir

### DIFF
--- a/templates/build-script-macos.tpl
+++ b/templates/build-script-macos.tpl
@@ -34,7 +34,7 @@ exists() {{
 }}
 
 ensure_dir() {{
-    [[ -n ${{1}} ]] && /bin/mkdir -p ${{1}} && builtin cd ${{1}}
+    [[ -n "${{1}}" ]] && /bin/mkdir -p "${{1}}" && builtin cd "${{1}}"
 }}
 
 cleanup() {{
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 caught_error() {{
     error "ERROR during build step: ${{1}}"
-    cleanup ${workspace}
+    cleanup {workspace}
     exit 1
 }}
 

--- a/templates/build-script-ubuntu.tpl
+++ b/templates/build-script-ubuntu.tpl
@@ -34,7 +34,7 @@ exists() {{
 }}
 
 ensure_dir() {{
-    [[ -n ${{1}} ]] && /bin/mkdir -p ${{1}} && builtin cd ${{1}}
+    [[ -n "${{1}}" ]] && /bin/mkdir -p "${{1}}" && builtin cd "${{1}}"
 }}
 
 cleanup() {{
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 caught_error() {{
     error "ERROR during build step: ${{1}}"
-    cleanup ${workspace}
+    cleanup {workspace}
     exit 1
 }}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

* Removed incorrect use of `$` in tpl file.
* Quote passed-in argument (path) of `ensure_dir` function. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

* `cleanup ${workspace}` expands to `cleanup $${BASE_DIR}`
* Without quoting, paths with spaces 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Created a bash script containing existing & fixed function `ensure_dir`. When passing a directory containing spaces, the existing function failed to work as intended; the fixed function correctly handled the directory with spaces.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
