### PR TITLE
CI: Add ability to enable artifact building with Github label

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -64,18 +64,19 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+
+      - name: 'Check for Github Labels'
+        if: github.event_name == 'pull_request'
+        run: |
+          if test -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')"; then
+            echo "SEEKING_TESTERS=1" >> $GITHUB_ENV
+          else
+            echo "SEEKING_TESTERS=0" >> $GITHUB_ENV
+          fi
+
       - name: Install Homebrew dependencies
         shell: bash
         run: |
-          if [ -d /usr/local/opt/openssl@1.0.2t ]; then
-              brew uninstall openssl@1.0.2t
-              brew untap local/openssl
-          fi
-
-          if [ -d /usr/local/opt/python@2.7.17 ]; then
-              brew uninstall python@2.7.17
-              brew untap local/python2
-          fi
           brew bundle
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
       - name: Get Current Date
@@ -600,7 +601,7 @@ jobs:
           fi
           mv ./macos-deps-${{ env.CURRENT_ARCH }}-${{ env.CURRENT_DATE }}.tar.gz ${{ github.workspace }}/macos
       - name: PublishBuildArtifacts
-        if: success() && github.event_name != 'pull_request'
+        if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         uses: actions/upload-artifact@v2.2.0
         with:
           name: 'macos-deps-${{ env.CURRENT_ARCH }}-${{ env.CURRENT_DATE }}'
@@ -615,6 +616,16 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+
+      - name: 'Check for Github Labels'
+        if: github.event_name == 'pull_request'
+        run: |
+          if test -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')"; then
+            echo "SEEKING_TESTERS=1" >> $GITHUB_ENV
+          else
+            echo "SEEKING_TESTERS=0" >> $GITHUB_ENV
+          fi
+
       - name: Install Homebrew dependencies
         shell: bash
         run: |
@@ -721,7 +732,7 @@ jobs:
           fi
           mv macos-qt-${{ env.MAC_QT_VERSION }}-${{ env.CURRENT_ARCH }}-${{ env.CURRENT_DATE }}.tar.gz ${{ github.workspace }}/macos
       - name: PublishBuildArtifacts
-        if: success() && github.event_name != 'pull_request'
+        if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         uses: actions/upload-artifact@v2.2.0
         with:
           name: 'macos-qt-${{ env.MAC_QT_VERSION }}-${{ env.CURRENT_ARCH }}-${{ env.CURRENT_DATE }}'


### PR DESCRIPTION
### Description
Enables functionality to trigger artifact creation even for pull requests if the `SEEKING_TESTERS` label is added to a pull request on Github.

### Motivation and Context
Allows testing of binaries generated by updated build scripts without the need to merge into the main codebase.

### How Has This Been Tested?
* Needs to be tested as part of this PR

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
