### PR TITLE
Add CACHE_REVISION key to ignored environment vars for script generation

### DIFF
--- a/.github/workflows/create_scripts.yml
+++ b/.github/workflows/create_scripts.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/main.yml'
       - '.github/workflows/create_scripts.yml'
+      - 'utils/build_script_generator.py'
       - '!CI/build-deps-macos.sh'
     branches:
       - master

--- a/utils/build_script_generator.py
+++ b/utils/build_script_generator.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 import os
 import re
@@ -30,6 +28,7 @@ def main() -> int:
                     for key, value in environment_data.items()
                     if key
                     not in [
+                        "CACHE_REVISION",
                         "MACOSX_DEPLOYMENT_TARGET",
                         "FFMPEG_REVISION",
                         "BLOCKED_FORMULAS",
@@ -41,11 +40,8 @@ def main() -> int:
                     [key.split("_")[0] for key in filtered_data.keys()]
                 ).keys()
                 dependency_strings = [
-                    (
-                        f'    "{key.lower()}'
-                        f" {environment_data.get(f'{key}_VERSION', '')}"
-                        f" {environment_data.get(f'{key}_HASH', '')}\""
-                    )
+                    f"    \"{key.lower()} {environment_data.get(f'{key}_VERSION', '')}"
+                    f" {environment_data.get(f'{key}_HASH', '')}\""
                     for key in dependencies
                 ]
 


### PR DESCRIPTION
### Description
Adds the CACHE_REVISION environment variable (as defined in the Github workflow) to the list of ignored variables for dependency updates in build scripts.

### Motivation and Context
Name, version and archive hash of dependencies are imported from the Github actions workflow file and added to the actual shell script contained in the repo. The added `CACHE_REVISION` variable was not ignored, thus possibly breaking build runs.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
