### PR TITLE
Fix ccache status output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         arch: ['x86_64', 'arm64']
     env:
       MACOSX_DEPLOYMENT_TARGET: '10.13'
-      CACHE_REVISION: '02'
+      CACHE_REVISION: '03'
       LIBPNG_VERSION: '1.6.37'
       LIBPNG_HASH: '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
       LIBOPUS_VERSION: '1.3.1-93-gdfd6c88a'

--- a/CI/include/build_support.sh
+++ b/CI/include/build_support.sh
@@ -82,7 +82,7 @@ _add_ccache_to_path() {
         PATH="/usr/local/opt/ccache/libexec:${PATH}"
         status "Compiler Info:"
         local IFS=$'\n'
-        for COMPILER_INFO in $(type cc c++ gcc g++ clang clang++); do
+        for COMPILER_INFO in $(type cc c++ gcc g++ clang clang++ || true); do
             info "${COMPILER_INFO}"
         done
     fi


### PR DESCRIPTION
### Description
Fixes the output of ccache detection which will exit with a non-zero return code if any of the listed compilers isn't present.

### Motivation and Context
Avoid build errors on systems where `clang` is not installed.

### How Has This Been Tested?
* Tested locally

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
