### PR TITLE
Fix install option being offered to main build script

### DIFF
--- a/CI/include/build_support_macos.sh
+++ b/CI/include/build_support_macos.sh
@@ -137,8 +137,11 @@ _print_usage() {
             "-q, --quiet                    : Suppress most build process output\n" \
             "-v, --verbose                  : Enable more verbose build process output\n" \
             "-a, --architecture             : Specify build architecture (default: host arch, alternatives: universal,x86_64, arm64)\n" \
-            "-s, --skip-dependency-checks   : Skip Homebrew dependency checks (default: off)\n" \
-            "-i, --install                  : Run installation (default: off)\n"
+            "-s, --skip-dependency-checks   : Skip Homebrew dependency checks (default: off)\n"
+
+    if [ -z _RUN_OBS_BUILD_SCRIPT ]; then
+        echo -e "-i, --install                  : Run installation (default: off)\n"
+    fi
 }
 
 _check_parameters() {


### PR DESCRIPTION
### Description
Fixes the install option (`-i` or `-install`) being offered by the main build script.

### Motivation and Context
The main build script creates a redistributable package of obs-deps, thus installs implicitly and doesn't support an explicit install switch.

### How Has This Been Tested?
* Tested locally

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
