### PR TITLE
Fix platform and architecture dependent ccache binary path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         arch: ['x86_64', 'arm64']
     env:
       MACOSX_DEPLOYMENT_TARGET: '10.13'
-      CACHE_REVISION: '03'
+      CACHE_REVISION: '04'
       LIBPNG_VERSION: '1.6.37'
       LIBPNG_HASH: '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
       LIBOPUS_VERSION: '1.3.1-93-gdfd6c88a'

--- a/CI/include/build_support.sh
+++ b/CI/include/build_support.sh
@@ -77,17 +77,6 @@ check_ccache() {
     fi
 }
 
-_add_ccache_to_path() {
-    if [ "${CMAKE_CCACHE_OPTIONS}" ]; then
-        PATH="/usr/local/opt/ccache/libexec:${PATH}"
-        status "Compiler Info:"
-        local IFS=$'\n'
-        for COMPILER_INFO in $(type cc c++ gcc g++ clang clang++ || true); do
-            info "${COMPILER_INFO}"
-        done
-    fi
-}
-
 safe_fetch() {
     if [ $# -lt 2 ]; then
         error "Usage: safe_fetch URL HASH"

--- a/CI/include/build_support_macos.sh
+++ b/CI/include/build_support_macos.sh
@@ -130,6 +130,20 @@ cleanup() {
 }
 
 ## DEFINE TEMPLATES ##
+_add_ccache_to_path() {
+    if [ "${CMAKE_CCACHE_OPTIONS}" ]; then
+        if [ "${CURRENT_ARCH}" == "arm64" ]; then
+            PATH="/opt/homebrew/opt/ccache/libexec:${PATH}"
+        else
+            PATH="/usr/local/opt/ccache/libexec:${PATH}"
+        fi
+        status "Compiler Info:"
+        local IFS=$'\n'
+        for COMPILER_INFO in $(type cc c++ gcc g++ clang clang++ || true); do
+            info "${COMPILER_INFO}"
+        done
+    fi
+}
 
 _print_usage() {
     echo -e "Usage: ${0}\n" \


### PR DESCRIPTION
### Description
Makes discovery of the ccache binary path platform and also architecture dependent (Homebrew paths have changed between x86_64 and arm64).

This will require adding a function `_add_cache_to_path` to the platform dependent build support include, even if just as a stub.

### Motivation and Context
Allows compatibility with different build platforms, e.g. for cross compiling Windows deps on Linux.

### How Has This Been Tested?
* Tested with a full build locally.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
