### PR TITLE
Remove spurious QMAKE_QUIET from deps build script

### DIFF
--- a/CI/build-deps-macos.sh
+++ b/CI/build-deps-macos.sh
@@ -44,7 +44,6 @@ REQUIRED_DEPS=(
 
 ## MAIN SCRIPT FUNCTIONS ##
 obs-deps-build-main() {
-    QMAKE_QUIET=TRUE
     CHECKOUT_DIR="$(/usr/bin/git rev-parse --show-toplevel)"
     BUILD_DIR="${CHECKOUT_DIR}/../obs-prebuilt-dependencies"
     source "${CHECKOUT_DIR}/CI/include/build_support.sh"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove spurious QMAKE_QUIET variable from deps build script

This flag appears to be used in the build-qt-macos.sh script and built_qt.sh script, but it is not used in the build-deps-macos.sh script or its related component scripts.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Unused variables are bad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
