### PR TITLE
Add architecture-dependent artifacts to release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -573,15 +573,75 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: 'Download deps artifact'
+      - name: 'Download x86_64 deps artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-deps-${{ env.CURRENT_DATE }}-x86_64.tar.xz
+
+      - name: 'Download x86_64 Qt artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-deps-qt-${{ env.CURRENT_DATE }}-x86_64.tar.xz
+
+      - name: 'Download arm64 deps artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-deps-${{ env.CURRENT_DATE }}-arm64.tar.xz
+
+      - name: 'Download arm64 Qt artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-deps-qt-${{ env.CURRENT_DATE }}-arm64.tar.xz
+
+      - name: 'Download universal deps artifact'
         uses: actions/download-artifact@v2
         with:
           name: macos-deps-${{ env.CURRENT_DATE }}-universal.tar.xz
 
-      - name: 'Download Qt artifact'
+      - name: 'Download universal Qt artifact'
         uses: actions/download-artifact@v2
         with:
           name: macos-deps-qt-${{ env.CURRENT_DATE }}-universal.tar.xz
+
+      - name: 'Upload macOS x86_64 package to release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-x86_64.tar.xz
+          asset_name: macos-deps-${{ steps.get_version.outputs.VERSION }}-x86_64.tar.xz
+          asset_content_type: application/octet-stream
+
+      - name: 'Upload macOS Qt x86_64 package to release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-x86_64.tar.xz
+          asset_name: macos-deps-qt-${{ steps.get_version.outputs.VERSION }}-x86_64.tar.xz
+          asset_content_type: application/octet-stream
+
+      - name: 'Upload macOS arm64 package to release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-arm64.tar.xz
+          asset_name: macos-deps-${{ steps.get_version.outputs.VERSION }}-arm64.tar.xz
+          asset_content_type: application/octet-stream
+
+      - name: 'Upload macOS Qt arm64 package to release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-arm64.tar.xz
+          asset_name: macos-deps-qt-${{ steps.get_version.outputs.VERSION }}-arm64.tar.xz
+          asset_content_type: application/octet-stream
 
       - name: 'Upload macOS universal package to release'
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
### Description
Adds architecture-dependent artifacts to the official release.

### Motivation and Context
While it's great that the universal deps allow building a universal OBS release, it requires building OBS without the browser-plugin.

For official releases we need to split architectures and to reduce app bundle file sizes it'd be great if we could use the architecture-specific deps for this builds. 

The artifacts are created anyway, this just adds steps to download them and add them to the release.

### How Has This Been Tested?
As it adds new steps to the workflow triggered by a release tag, this requires a release on Github.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
