### PR TITLE
Make deployment targets architecture aware

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,9 @@ jobs:
       matrix:
         arch: ['x86_64', 'arm64']
     env:
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
-      CACHE_REVISION: '04'
+      MACOSX_DEPLOYMENT_TARGET_X86_64: '10.13'
+      MACOSX_DEPLOYMENT_TARGET_ARM64: '11.0'
+      CACHE_REVISION: '05'
       LIBPNG_VERSION: '1.6.37'
       LIBPNG_HASH: '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
       LIBOPUS_VERSION: '1.3.1-93-gdfd6c88a'
@@ -54,7 +55,7 @@ jobs:
       LIBFREETYPE_HASH: '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
       LIBRNNOISE_VERSION: '2020-07-28'
       LIBRNNOISE_HASH: '90ec41ef659fd82cfec2103e9bb7fc235e9ea66c'
-      BLOCKED_FORMULAS: 'ant gradle maven selenium-server-standalone llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt'
+      BLOCKED_FORMULAS: 'ant gradle maven selenium-server selenium-server-standalone llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg composer php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt'
     defaults:
       run:
         shell: bash
@@ -343,7 +344,7 @@ jobs:
       QT_REVISION: '03'
       QT_VERSION: '5.15.2'
       QT_HASH: '3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240'
-      BLOCKED_FORMULAS: 'ant gradle maven selenium-server-standalone llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt'
+      BLOCKED_FORMULAS: 'ant gradle maven selenium-server selenium-server-standalone llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg composer php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt'
     defaults:
       run:
         shell: bash

--- a/CI/include/build_support_macos.sh
+++ b/CI/include/build_support_macos.sh
@@ -11,17 +11,8 @@
 # Setup build environment
 
 # Get fallback macOS deployment target from default workflow
-CI_MACOSX_DEPLOYMENT_TARGET=$(/bin/cat "${CI_WORKFLOW}" | /usr/bin/sed -En "s/[ ]+MACOSX_DEPLOYMENT_TARGET: '([0-9\.]+)'/\1/p" | head -1)
-
-# Export MACOSX_DEPLOYMENT_TARGET which is picked up by some build scripts
-export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-${CI_MACOSX_DEPLOYMENT_TARGET}}"
-
-# Set Darwin version identifier based on MACOSX_DEPLOYMENT_TARGET
-if [ $(echo "${MACOSX_DEPLOYMENT_TARGET}" | cut -d "." -f 1) -lt 11 ]; then
-    DARWIN_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 2)+4))"
-else
-    DARWIN_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 1)+9))"
-fi
+CI_MACOSX_DEPLOYMENT_TARGET_X86_64=$(/bin/cat "${CI_WORKFLOW}" | /usr/bin/sed -En "s/[ ]+MACOSX_DEPLOYMENT_TARGET_X86_64: '([0-9\.]+)'/\1/p" | head -1)
+CI_MACOSX_DEPLOYMENT_TARGET_ARM64=$(/bin/cat "${CI_WORKFLOW}" | /usr/bin/sed -En "s/[ ]+MACOSX_DEPLOYMENT_TARGET_ARM64: '([0-9\.]+)'/\1/p" | head -1)
 
 # Ensure using the most recent macOS SDK
 export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
@@ -47,6 +38,24 @@ fi
 
 ## DEFINE UTILITIES ##
 check_macos_version() {
+    ARCH="${ARCH:-${CURRENT_ARCH}}"
+    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "universal" ]; then
+        CI_MACOSX_DEPLOYMENT_TARGET="${CI_MACOSX_DEPLOYMENT_TARGET_X86_64}"
+    elif [ "${ARCH}" = "arm64" ]; then
+        CI_MACOSX_DEPLOYMENT_TARGET="${CI_MACOSX_DEPLOYMENT_TARGET_ARM64}"
+    else
+        caught_error "Unsupported architecture '${ARCH}' provided"
+    fi
+
+    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-${CI_MACOSX_DEPLOYMENT_TARGET}}"
+
+    # Set Darwin version identifier based on MACOSX_DEPLOYMENT_TARGET
+    if [ $(echo "${MACOSX_DEPLOYMENT_TARGET}" | cut -d "." -f 1) -lt 11 ]; then
+        DARWIN_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 2)+4))"
+    else
+        DARWIN_TARGET="$(($(echo ${MACOSX_DEPLOYMENT_TARGET} | cut -d "." -f 1)+9))"
+    fi
+
     step "Check macOS version..."
     MIN_VERSION=${MACOSX_DEPLOYMENT_TARGET}
     MIN_MAJOR=$(echo ${MIN_VERSION} | /usr/bin/cut -d '.' -f 1)
@@ -178,8 +187,8 @@ _build_checks() {
     CI_PRODUCT_VERSION=$(/bin/cat "${CI_WORKFLOW}" | /usr/bin/sed -En "s/[ ]+${PRODUCT_NAME_U}_VERSION: '(.+)'/\1/p")
     CI_PRODUCT_HASH=$(/bin/cat "${CI_WORKFLOW}" | /usr/bin/sed -En "s/[ ]+${PRODUCT_NAME_U}_HASH: '([0-9a-f]+)'/\1/p")
 
-    check_macos_version
     check_archs
+    check_macos_version
 
     if [ -z "${INSTALL}" ]; then
         check_ccache


### PR DESCRIPTION
### Description
Enables per-architecture deployment targets for CI builds.

### Motivation and Context
During dogfooding it became aware that in contrast to the PR to enable M1 support for obs-studio the obs-deps repo still uses the same deployment target for arm64 and x86_64. As we use the per-architecture variant for building OBS now, this was an oversight.

### How Has This Been Tested?
* Tested with x86_64 and arm64 builds

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
