### PR TITLE
Update create release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,23 +149,6 @@ jobs:
             ${{ github.workspace }}/macos_build_temp/srt-${{ env.LIBSRT_VERSION }}
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.FFMPEG_DEP_HASH }}
 
-      - name: 'Restore ntv2 from cache'
-        id: ntv2-cache
-        uses: actions/cache@v2.1.6
-        env:
-          CACHE_NAME: 'ntv2-${{ matrix.arch }}-${{ env.CACHE_REVISION }}'
-        with:
-          path: ${{ github.workspace }}/macos_build_temp/ntv2-${{ env.NTV2_VERSION }}
-          key: ${{ runner.os }}-deps-${{ env.CACHE_NAME }}-${{ env.NTV2_VERSION }}
-
-      - name: 'Build dependency ntv2'
-        if: steps.ntv2-cache.outputs.cache-hit != 'true'
-        run: CI/macos/build_ntv2.sh -s -a ${{ matrix.arch }}
-
-      - name: 'Install dependency ntv2'
-        if: steps.ntv2-cache.outputs.cache-hit == 'true'
-        run: CI/macos/build_ntv2.sh -s -a ${{ matrix.arch }} --install
-
       - name: 'Build dependency libpng'
         if: steps.ffmpeg-deps-cache.outputs.cache-hit != 'true'
         run: CI/macos/build_libpng.sh -s -a ${{ matrix.arch }}
@@ -287,6 +270,23 @@ jobs:
         with:
           path: ${{ github.workspace }}/macos_build_temp/speexdsp-SpeexDSP-${{ env.SPEEXDSP_VERSION }}
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.SPEEXDSP_VERSION }}
+
+      - name: 'Restore ntv2 from cache'
+        id: ntv2-cache
+        uses: actions/cache@v2.1.6
+        env:
+          CACHE_NAME: 'ntv2-${{ matrix.arch }}-${{ env.CACHE_REVISION }}'
+        with:
+          path: ${{ github.workspace }}/macos_build_temp/ntv2-${{ env.NTV2_VERSION }}
+          key: ${{ runner.os }}-deps-${{ env.CACHE_NAME }}-${{ env.NTV2_VERSION }}
+
+      - name: 'Build dependency ntv2'
+        if: steps.ntv2-cache.outputs.cache-hit != 'true'
+        run: CI/macos/build_ntv2.sh -s -a ${{ matrix.arch }}
+
+      - name: 'Install dependency ntv2'
+        if: steps.ntv2-cache.outputs.cache-hit == 'true'
+        run: CI/macos/build_ntv2.sh -s -a ${{ matrix.arch }} --install
 
       - name: 'Build dependency SpeexDSP'
         if: steps.speexdsp-cache.outputs.cache-hit != 'true'
@@ -619,17 +619,6 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-      - name: 'Create Release'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: OBS Deps build ${{ steps.get_version.outputs.VERSION }}
-          draft: false
-          prerelease: false
-
       - name: 'Download x86_64 deps artifact'
         uses: actions/download-artifact@v2
         with:
@@ -660,62 +649,24 @@ jobs:
         with:
           name: macos-deps-qt-${{ env.CURRENT_DATE }}-universal.tar.xz
 
-      - name: 'Upload macOS x86_64 package to release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-x86_64.tar.xz
-          asset_name: macos-deps-${{ steps.get_version.outputs.VERSION }}-x86_64.tar.xz
-          asset_content_type: application/octet-stream
+      - name: 'Generate checksums'
+        run: |
+          echo "### Checksums\n" > ${{ github.workspace }}/RELEASE.txt
+          find . -name "macos-deps-*.tar.xz" -print0 | sort -z | xargs -0 -n 1 -P 1 -I {} sh -c "echo \"    \$(basename {}): \$(sha256sum {} | cut -c 1-64)\" >> ${{ github.workspace }}/RELEASE.txt"
 
-      - name: 'Upload macOS Qt x86_64 package to release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Create Release'
+        id: create_release
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-x86_64.tar.xz
-          asset_name: macos-deps-qt-${{ steps.get_version.outputs.VERSION }}-x86_64.tar.xz
-          asset_content_type: application/octet-stream
-
-      - name: 'Upload macOS arm64 package to release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-arm64.tar.xz
-          asset_name: macos-deps-${{ steps.get_version.outputs.VERSION }}-arm64.tar.xz
-          asset_content_type: application/octet-stream
-
-      - name: 'Upload macOS Qt arm64 package to release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-arm64.tar.xz
-          asset_name: macos-deps-qt-${{ steps.get_version.outputs.VERSION }}-arm64.tar.xz
-          asset_content_type: application/octet-stream
-
-      - name: 'Upload macOS universal package to release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-universal.tar.xz
-          asset_name: macos-deps-${{ steps.get_version.outputs.VERSION }}-universal.tar.xz
-          asset_content_type: application/octet-stream
-
-      - name: 'Upload macOS Qt universal package to release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-universal.tar.xz
-          asset_name: macos-deps-qt-${{ steps.get_version.outputs.VERSION }}-universal.tar.xz
-          asset_content_type: application/octet-stream
+          draft: false
+          prerelease: false
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          name: "OBS macOS Deps Build ${{ steps.get_version.outputs.VERSION }}"
+          body_path: ${{ github.workspace }}/RELEASE.txt
+          files: |
+            ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-x86_64.tar.xz
+            ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-arm64.tar.xz
+            ${{ github.workspace }}/macos-deps-${{ env.CURRENT_DATE }}-universal.tar.xz
+            ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-x86_64.tar.xz
+            ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-arm64.tar.xz
+            ${{ github.workspace }}/macos-deps-qt-${{ env.CURRENT_DATE }}-universal.tar.xz

--- a/CI/macos/build_qt.sh
+++ b/CI/macos/build_qt.sh
@@ -17,6 +17,7 @@ _patch_product() {
     if [ -z "${SKIP_UNPACK}" ]; then
         step "Apply patches..."
         apply_patch "${CHECKOUT_DIR}/CI/patches/QTBUG-74606.patch" "6ba73e94301505214b85e6014db23b042ae908f2439f0c18214e92644a356638"
+        apply_patch "${CHECKOUT_DIR}/CI/macos/patches/QTBUG-97855.patch" "d8620262ad3f689fdfe6b6e277ddfdd3594db3de9dbc65810a871f142faa9966"
         apply_patch "${CHECKOUT_DIR}/CI/macos/patches/QTBUG-90370.patch" "277b16f02f113e60579b07ad93c35154d7738a296e3bf3452182692b53d29b85"
         find . -type f -name "*.pro" -print0 | xargs -0 -I{} sh -c "echo '\n\nCONFIG += sdk_no_version_check' >> {}"
     fi

--- a/CI/macos/patches/QTBUG-97855.patch
+++ b/CI/macos/patches/QTBUG-97855.patch
@@ -1,0 +1,10 @@
+--- ./qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h     2020-10-27 09:02:11.000000000 +0100
++++ ./qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h   2021-11-23 20:32:10.000000000 +0100
+@@ -41,6 +41,7 @@
+ #define QIOSURFACEGRAPHICSBUFFER_H
+ 
+ #include <qpa/qplatformgraphicsbuffer.h>
++#include <CoreGraphics/CGColorSpace.h>
+ #include <private/qcore_mac_p.h>
+ 
+ QT_BEGIN_NAMESPACE


### PR DESCRIPTION
### Description
Updates the GitHub action used to create releases with a community variant as GitHub's own has been archived and is non-maintained.

Also adds the checksums of generated downloads to release body and fixes an obscure build bug with Qt.

### Motivation and Context
Keep GitHub action maintained and current, also makes it easier to update workflows using these dependencies to implement hash checks.

### How Has This Been Tested?
* Test on fork with commits to master branch and release tags

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
