### PR TITLE
windows: Remove an LDARG which is not used.

### DIFF
--- a/CI/windows/build_librist.sh
+++ b/CI/windows/build_librist.sh
@@ -33,7 +33,7 @@ _build_product() {
         -Dbuiltin_cjson=true \
         -Dtest=false \
         -Dbuilt_tools=false \
-        -Dc_link_args="-static-libgcc -Wl,-Bstatic -pthread" \
+        -Dc_link_args="-static-libgcc" \
         -Dhave_mingw_pthreads=false \
         -Dpkg_config_path="${BUILD_DIR}/lib/pkgconfig"
     step "Build (${ARCH})..."


### PR DESCRIPTION
### Description
Librist is built without pthread through a shim. So it's not necessary to use -Wl,-Bstatic -pthread as a linking argument since pthread is not used. The argument is therefore removed.

### Motivation and Context
Code cleanup.
The linking argument is not used since pthread is not included so it is innocuous.
But this is cleaner that way.

### How Has This Been Tested?
Built librist.dll , checked it had no stray dll (libgcc nor libwinpthread).
Then checked that obs-studio streamed fine to a rist server by watching a stream on a web player.

### Types of changes
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
