### PR TITLE
windows: Build AJA debug library

### DIFF
--- a/.github/workflows/windows_deps.yml
+++ b/.github/workflows/windows_deps.yml
@@ -270,7 +270,7 @@ jobs:
       matrix:
         arch: ['32', '64']
     env:
-      CACHE_REVISION: '01'
+      CACHE_REVISION: '02'
       MBEDTLS_VERSION: '2.24.0'
       MBEDTLS_HASH: '523f0554b6cdc7ace5d360885c3f5bbcc73ec0e8'
       CMOCKA_VERSION: '1.1.5-git'
@@ -536,13 +536,21 @@ jobs:
           path: ${{ github.workspace }}/windows_native_build_temp/ntv2*
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.NTV2_VERSION }}
 
-      - name: 'Build dependency ntv2'
+      - name: 'Build dependency ntv2 Release'
         if: steps.ntv2-cache.outputs.cache-hit != 'true'
         run: CI/windows/build_ntv2.ps1 -SkipDependencyChecks -BuildArch ${{ matrix.arch }}-bit
 
-      - name: 'Install dependency ntv2'
+      - name: 'Install dependency ntv2 Release'
         if: steps.ntv2-cache.outputs.cache-hit == 'true'
         run: CI/windows/build_ntv2.ps1 -SkipDependencyChecks -BuildArch ${{ matrix.arch }}-bit -Install
+
+      - name: 'Build dependency ntv2 Debug'
+        if: steps.ntv2-cache.outputs.cache-hit != 'true'
+        run: CI/windows/build_ntv2.ps1 -SkipDependencyChecks -BuildArch ${{ matrix.arch }}-bit -BuildConfiguration Debug
+
+      - name: 'Install dependency ntv2 Debug'
+        if: steps.ntv2-cache.outputs.cache-hit == 'true'
+        run: CI/windows/build_ntv2.ps1 -SkipDependencyChecks -BuildArch ${{ matrix.arch }}-bit -Install -BuildConfiguration Debug
 
       - name: 'Package dependencies'
         if: success()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

windows: Build AJA debug library

The OBS AJA plugin (aja) currently requires both the Release and Debug versions of the ajantv2 library to be able to build. This enables CI to build both Release and Debug versions of the library. Local builds with the build-deps-windows-native.ps1 script will still only produce a single build in the RelWithDebInfo configuration. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Make using obs-deps easier.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
