### PR TITLE
Add libxcb to removed packages for maOS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       LIBFREETYPE_HASH: '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
       LIBRNNOISE_VERSION: '2020-07-28'
       LIBRNNOISE_HASH: '90ec41ef659fd82cfec2103e9bb7fc235e9ea66c'
-      BLOCKED_FORMULAS: 'ant gradle maven selenium-server selenium-server-standalone llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg composer php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt libxft'
+      BLOCKED_FORMULAS: 'ant gradle maven selenium-server selenium-server-standalone llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg composer php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt libxft libxcb'
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Description
Adds `libxcb` to list of Homebrew packages to be removed before building FFmpeg.

### Motivation and Context
FFmpeg is built and linked against libcxb on CI, which breaks compilation on hosts without it.

### How Has This Been Tested?
* Needs to be tested on CI

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
