### PR TITLE
CI: Fix static library placement and create architecture-dependent release artifacts (Windows)

### DIFF
--- a/.github/workflows/windows_deps.yml
+++ b/.github/workflows/windows_deps.yml
@@ -692,8 +692,15 @@ jobs:
         with:
           name: windows-deps-${{ env.CURRENT_DATE }}
 
-      - name: 'Zip Windows deps artifact'
-        run: 7z a windows-deps-${{ env.CURRENT_DATE }}.zip win32 win64 -mx9
+      - name: 'Zip Windows deps artifacts'
+        run: |
+          pushd win64 > /dev/null
+          zip -r ../windows-deps-${{ env.CURRENT_DATE }}-x64.zip *
+          popd
+          pushd win32 > /dev/null
+          zip -r ../windows-deps-${{ env.CURRENT_DATE }}-x86.zip *
+          popd
+          zip -r windows-deps-${{ env.CURRENT_DATE }}.zip win32 win64
 
       - name: 'Upload Windows deps package to release'
         uses: actions/upload-release-asset@v1
@@ -703,4 +710,24 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ${{ github.workspace }}/windows-deps-${{ env.CURRENT_DATE }}.zip
           asset_name: windows-deps-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_content_type: application/octet-stream
+
+      - name: 'Upload 64-bit Windows deps package to release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/windows-deps-${{ env.CURRENT_DATE }}-x64.zip
+          asset_name: windows-deps-${{ steps.get_version.outputs.VERSION }}-x64.zip
+          asset_content_type: application/octet-stream
+
+      - name: 'Upload 32-bit Windows deps package to release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/windows-deps-${{ env.CURRENT_DATE }}-x86.zip
+          asset_name: windows-deps-${{ steps.get_version.outputs.VERSION }}-x86.zip
           asset_content_type: application/octet-stream

--- a/CI/windows/build_libvpx.sh
+++ b/CI/windows/build_libvpx.sh
@@ -17,7 +17,7 @@ _fixup_libs() {
     $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool \
         -m $WIN_CROSS_MVAL \
         -d libvpx.def \
-        -l "${BUILD_DIR}"/bin/vpx.lib \
+        -l "${BUILD_DIR}"/lib/vpx.lib \
         -D "${BUILD_DIR}"/bin/$vpxname
 }
 

--- a/CI/windows/build_libx264.sh
+++ b/CI/windows/build_libx264.sh
@@ -18,7 +18,7 @@ _fixup_libs() {
     grep "EXPORTS\|x264" "${BUILD_DIR}"/bin/x264.orig.def > "${BUILD_DIR}"/bin/x264.def
     rm -f "${BUILD_DIR}"/bin/x264.orig.def
     sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" "${BUILD_DIR}"/bin/x264.def
-    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d "${BUILD_DIR}"/bin/x264.def -l "${BUILD_DIR}"/bin/x264.lib -D "${BUILD_DIR}"/bin/$x264name
+    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d "${BUILD_DIR}"/bin/x264.def -l "${BUILD_DIR}"/lib/x264.lib -D "${BUILD_DIR}"/bin/$x264name
 }
 
 _build_product() {

--- a/CI/windows/build_luajit.ps1
+++ b/CI/windows/build_luajit.ps1
@@ -38,7 +38,8 @@ function Install-Product {
 
     Write-Step "Install (${ARCH})..."
     New-Item -Path "${CMAKE_INSTALL_DIR}\include\luajit" -ItemType Directory -Force
-    Copy-Item -Path @("${DepsBuildDir}\${ProductFolder}\src\lua51.dll", "${DepsBuildDir}\${ProductFolder}\src\lua51.lib", "${DepsBuildDir}\${ProductFolder}\src\luajit.lib") -Destination "${CMAKE_INSTALL_DIR}\bin"
+    Copy-Item -Path @("${DepsBuildDir}\${ProductFolder}\src\lua51.dll") -Destination "${CMAKE_INSTALL_DIR}\bin"
+    Copy-Item -Path @("${DepsBuildDir}\${ProductFolder}\src\lua51.lib", "${DepsBuildDir}\${ProductFolder}\src\luajit.lib") -Destination "${CMAKE_INSTALL_DIR}\lib"
     Copy-Item -Path "${DepsBuildDir}\${ProductFolder}\src\*.h" -Destination "${CMAKE_INSTALL_DIR}\include\luajit"
 }
 

--- a/CI/windows/build_mbedtls.sh
+++ b/CI/windows/build_mbedtls.sh
@@ -55,9 +55,9 @@ _install_product() {
     sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedtls.def
     sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedcrypto.def
     sed -i -e "/\\t.*DATA/d" -e "/\\t\".*/d" -e "s/\s@.*//" mbedx509.def
-    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d mbedtls.def -l ${BUILD_DIR}/bin/mbedtls.lib -D library/libmbedtls.dll
-    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d mbedcrypto.def -l ${BUILD_DIR}/bin/mbedcrypto.lib -D library/libmbedcrypto.dll
-    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d mbedx509.def -l ${BUILD_DIR}/bin/mbedx509.lib -D library/libmbedx509.dll
+    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d mbedtls.def -l ${BUILD_DIR}/lib/mbedtls.lib -D library/libmbedtls.dll
+    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d mbedcrypto.def -l ${BUILD_DIR}/lib/mbedcrypto.lib -D library/libmbedcrypto.dll
+    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d mbedx509.def -l ${BUILD_DIR}/lib/mbedx509.lib -D library/libmbedx509.dll
 
     make install
     mv "${BUILD_DIR}"/lib/*.dll "${BUILD_DIR}"/bin

--- a/CI/windows/build_zlib.sh
+++ b/CI/windows/build_zlib.sh
@@ -15,7 +15,7 @@ _fixup_libs() {
     mv "${BUILD_DIR}"/lib/libzlib.dll.a "${BUILD_DIR}"/lib/libz.dll.a
     mv "${BUILD_DIR}"/lib/libzlibstatic.a "${BUILD_DIR}"/lib/libz.a
     cp ../win32/zlib.def "${BUILD_DIR}"/bin
-    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d ../win32/zlib.def -l "${BUILD_DIR}"/bin/zlib.lib -D "${BUILD_DIR}"/bin/zlib.dll
+    $WIN_CROSS_TOOL_PREFIX-w64-mingw32-dlltool -m $WIN_CROSS_MVAL -d ../win32/zlib.def -l "${BUILD_DIR}"/lib/zlib.lib -D "${BUILD_DIR}"/bin/zlib.dll
 
     cd "${BUILD_DIR}"
     apply_patch "${CHECKOUT_DIR}/CI/windows/patches/zlib/zlib-include-zconf.patch" "e7534bbf425d4670757b329eebb7c997e4ab928030c7479bdd8fc872e3c6e728"


### PR DESCRIPTION
### Description
This PR introduces two changes to windows-reps:

1. It ensures all import libraries and static libraries (`.lib` suffix) are placed inside the `lib` folder.2. 
2. On top of the classic "combined" dependency download, it also creates separate x64 and x86 downloads

### Motivation and Context
CMake finders expect libraries to be found inside the `lib` directory of a specified PREFIX path. While OBS' own finders use multiple directories as additional "hints" for finding dependencies, the defaults ones do not and are stricter in this regard.

This mainly affects "cURL" within a standard OBS build and required adding additional paths to the `CMAKE_PREFIX_PATH` in the CMake rework. By placing the static libraries and import libraries in the correct directory, no additional paths are needed for PREFIXES or custom CMake finders.

Splitting up the downloads reduces download sizes and decompression effort.

### How Has This Been Tested?
* OBS compiled with new deps on Windows
* OBS run with new deps on Windows
* Workflow runs tested on CI
* Release creation tested on CI

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
