### PR TITLE
macos/patches: Cherry-Pick QT macOS text spacing patch

### DIFF
--- a/CI/macos/build_qt.sh
+++ b/CI/macos/build_qt.sh
@@ -17,6 +17,7 @@ _patch_product() {
     if [ -z "${SKIP_UNPACK}" ]; then
         step "Apply patches..."
         apply_patch "${CHECKOUT_DIR}/CI/patches/QTBUG-74606.patch" "6ba73e94301505214b85e6014db23b042ae908f2439f0c18214e92644a356638"
+        apply_patch "${CHECKOUT_DIR}/CI/macos/patches/QTBUG-88495.patch" "d60d663d2d940aa21cbcda65b1e60c4ecb1ec1900736e896367e5436d121206e"
         apply_patch "${CHECKOUT_DIR}/CI/macos/patches/QTBUG-97855.patch" "d8620262ad3f689fdfe6b6e277ddfdd3594db3de9dbc65810a871f142faa9966"
         apply_patch "${CHECKOUT_DIR}/CI/macos/patches/QTBUG-90370.patch" "277b16f02f113e60579b07ad93c35154d7738a296e3bf3452182692b53d29b85"
         find . -type f -name "*.pro" -print0 | xargs -0 -I{} sh -c "echo '\n\nCONFIG += sdk_no_version_check' >> {}"

--- a/CI/macos/patches/QTBUG-88495.patch
+++ b/CI/macos/patches/QTBUG-88495.patch
@@ -1,0 +1,66 @@
+From 6d306a0e3755258beb11d7f488c2bb1bf66bec19 Mon Sep 17 00:00:00 2001
+From: Eskil Abrahamsen Blomfeldt <eskil.abrahamsen-blomfeldt@qt.io>
+Date: Tue, 17 Nov 2020 09:23:39 +0100
+Subject: [PATCH 1/1] Fix shaping problems on iOS 14 / macOS 11
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+Detection of AAT fonts was exclusively based on the existence
+of tables mort, morx and kerx. In the SF font (the UI default)
+on iOS 14 and Big Sur, none of these tables actually exist, so
+we would accidentally use the OpenType shaper for it. But there
+are plenty of other AAT tables in the font and the OT shaper
+canÂ´t handle it. In particular, this caused us to get the wrong
+advance for comma when it was followed by a space.
+
+Looking at all the affected SF fonts on Big Sur, they all have
+the trak table, so we expand the detection to include this.
+This is possibly also the table used to determine the correct
+glyph positions in this case.
+
+In Qt 6, this already works as expected, because Harfbuzz has
+built-in support for AAT and does not require the CoreText
+fallback. Therefore, this is just a hotfix for the 5.15 series
+and there is no need to upstream this patch.
+
+[ChangeLog][macOS] Fixed shaping of default UI font on macOS 11
+and iOS 14.
+
+Fixes: QTBUG-88495
+Change-Id: Ia2b3f45cbc0c32b93864760cb427ede6b0566e8f
+Reviewed-by: Tor Arne VestbÃ¸ <tor.arne.vestbo@qt.io>
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+---
+ src/3rdparty/harfbuzz-ng/src/hb-coretext.cc | 2 +-
+ src/3rdparty/harfbuzz-ng/src/hb-coretext.h  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc b/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
+index d64cb7edbd81..11b6deee045a 100644
+--- ./qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
++++ ./qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
+@@ -1322,7 +1322,7 @@ struct hb_coretext_aat_shaper_face_data_t {};
+ hb_coretext_aat_shaper_face_data_t *
+ _hb_coretext_aat_shaper_face_data_create (hb_face_t *face)
+ {
+-  static const hb_tag_t tags[] = {HB_CORETEXT_TAG_MORX, HB_CORETEXT_TAG_MORT, HB_CORETEXT_TAG_KERX};
++  static const hb_tag_t tags[] = {HB_CORETEXT_TAG_MORX, HB_CORETEXT_TAG_MORT, HB_CORETEXT_TAG_KERX, HB_CORETEXT_TAG_TRAK};
+ 
+   for (unsigned int i = 0; i < ARRAY_LENGTH (tags); i++)
+   {
+diff --git a/src/3rdparty/harfbuzz-ng/src/hb-coretext.h b/src/3rdparty/harfbuzz-ng/src/hb-coretext.h
+index 4b0a6f01b6f6..12f7d2515bd2 100644
+--- ./qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.h
++++ ./qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.h
+@@ -43,7 +43,7 @@ HB_BEGIN_DECLS
+ #define HB_CORETEXT_TAG_MORT HB_TAG('m','o','r','t')
+ #define HB_CORETEXT_TAG_MORX HB_TAG('m','o','r','x')
+ #define HB_CORETEXT_TAG_KERX HB_TAG('k','e','r','x')
+-
++#define HB_CORETEXT_TAG_TRAK HB_TAG('t','r','a','k')
+ 
+ HB_EXTERN hb_face_t *
+ hb_coretext_face_create (CGFontRef cg_font);
+-- 
+2.16.3

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Scripts to build and package dependencies for OBS on CI
 * SpeexDSP is patched to allow macOS 10.13 compatibility
 * Qt is patched to cross-compile ARM64 on x86_64 hosts
 * Qt is patched to fix https://bugreports.qt.io/browse/QTBUG-74606
+* Qt is patched to fix https://bugreports.qt.io/browse/QTBUG-88495
 * Qt is patched to fix https://bugreports.qt.io/browse/QTBUG-90370
 * Qt is patched to fix https://bugreports.qt.io/browse/QTBUG-97855
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds https://github.com/qt/qtbase/commit/6d306a0 to our patches.

The problem itself doesn't seem to be easily reproducible (Matt couldn't do so), but it always happens to me and doesn't anymore with QT built with this patch (you can find test artifacts from GHA [here](https://github.com/gxalpha/obs-deps/actions/runs/2141442917)).

Before:
<img width="420" alt="Bildschirmfoto 2022-04-10 um 09 42 33" src="https://user-images.githubusercontent.com/59806498/162608388-5623b799-337b-4c4c-a393-7c0ddbeb914e.png">


After:
<img width="420" alt="Bildschirmfoto 2022-04-10 um 09 41 39" src="https://user-images.githubusercontent.com/59806498/162608385-15b09e6f-8482-40a1-ba42-09004b4a0640.png">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix https://github.com/obsproject/obs-studio/issues/4041 until we move to QT6.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built QT on GitHub Actions (see link above) and compiled OBS against the build artifact.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
