### PR TITLE
CI: Optimize macOS Qt build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -397,7 +397,7 @@ jobs:
         arch: ['x86_64', 'arm64']
     env:
       MACOSX_DEPLOYMENT_TARGET: '10.13'
-      QT_REVISION: '03'
+      QT_REVISION: '04'
       QT_VERSION: '5.15.2'
       QT_HASH: '3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240'
       BLOCKED_FORMULAS: 'llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile libogg composer php gd freetype fontconfig webp libpng lame libtiff opus kotlin sbt libxft libxcb'

--- a/CI/macos/build_qt.sh
+++ b/CI/macos/build_qt.sh
@@ -104,13 +104,22 @@ _configure_qt_x86_64() {
     ../configure ${CMAKE_CCACHE_OPTIONS:+-ccache} ${QMAKE_QUIET:+-silent}  \
         -release -opensource -confirm-license -system-zlib \
         -qt-libpng -qt-libjpeg -qt-freetype -qt-pcre \
-        -nomake examples -nomake tests -no-glib \
+        -nomake examples -nomake tests \
+        -no-compile-examples -no-dbus -no-glib \
+        -no-feature-itemmodeltester -no-feature-printdialog -no-feature-printer \
+        -no-feature-printpreviewdialog -no-feature-printpreviewwidget -no-feature-sql -no-feature-sqlmodel \
+        -no-feature-testlib \
+        -no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc -no-sql-psql -no-sql-sqlite2 \
+        -no-sql-sqlite -no-sql-tds \
+        -DQT_NO_PDF -DQT_NO_PRINTER \
         -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d \
-        -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtlocation \
-        -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtspeech \
-        -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
+        -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtlocation -skip qtlottie \
+        -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols -skip qtquickcontrols2 \
+        -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus \
+        -skip qtserialport -skip qtspeech -skip qttools -skip qttranslations -skip qtvirtualkeyboard \
+        -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
         -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns \
-        --prefix="${BUILD_DIR}" -pkg-config -dbus-runtime QMAKE_APPLE_DEVICE_ARCHS="x86_64"
+        --prefix="${BUILD_DIR}" -pkg-config QMAKE_APPLE_DEVICE_ARCHS="x86_64"
 }
 
 _build_qt_arm64() {
@@ -128,13 +137,22 @@ _configure_qt_arm64() {
     ../configure ${CMAKE_CCACHE_OPTIONS:+-ccache} ${QMAKE_QUIET:+-silent} \
         -release -opensource -confirm-license -system-zlib \
         -qt-libpng -qt-libjpeg -qt-freetype -qt-pcre \
-        -nomake examples -nomake tests -no-glib \
+        -nomake examples -nomake tests \
+        -no-compile-examples -no-dbus -no-glib \
+        -no-feature-itemmodeltester -no-feature-printdialog -no-feature-printer \
+        -no-feature-printpreviewdialog -no-feature-printpreviewwidget -no-feature-sql -no-feature-sqlmodel \
+        -no-feature-testlib \
+        -no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc -no-sql-psql -no-sql-sqlite2 \
+        -no-sql-sqlite -no-sql-tds \
+        -DQT_NO_PDF -DQT_NO_PRINTER \
         -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d \
-        -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtlocation \
-        -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtspeech \
-        -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
+        -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtlocation -skip qtlottie \
+        -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols -skip qtquickcontrols2 \
+        -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus \
+        -skip qtserialport -skip qtspeech -skip qttools -skip qttranslations -skip qtvirtualkeyboard \
+        -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin \
         -skip qtwebsockets -skip qtwebview -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns \
-        --prefix="${BUILD_DIR}" -pkg-config -dbus-runtime QMAKE_APPLE_DEVICE_ARCHS="arm64"
+        --prefix="${BUILD_DIR}" -pkg-config QMAKE_APPLE_DEVICE_ARCHS="arm64"
 }
 
 _prepare_cross_compile() {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Port some configuration options from our Windows Qt build to our macOS Qt build to reduce the build time and build size.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Reducing the build time helps us validate PRs and commits faster and lets us free up macOS CI instances faster.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I let this build on my fork's CI. I checked the build time and artifact size. Both build time and artifact size were reduced from before these changes.

If we want to be thorough, someone should build OBS on macOS against this Qt build to make sure that nothing breaks.

#### Before PR
![image](https://user-images.githubusercontent.com/624931/165632457-b6e70354-2993-4e7b-a043-3d6c262429d9.png)
##### Build time (build only)
* x86_64: 1h09m35s
* arm64: 1h36m29s

##### Build size (compressed CI artifact)
* x86_64: 18.9 MB
* arm64: 20.5 MB
* universal: 28.3 MB

##### Build size (uncompressed)
* x86_64: 83.2 MB
* arm64: 99.9 MB
* universal: 140 MB

#### After PR
<!-- before removing dbus ![image](https://user-images.githubusercontent.com/624931/165632489-3d56c112-4b6b-43c7-88b0-62cafde0e4d7.png) -->
![image](https://user-images.githubusercontent.com/624931/167020843-af1477ee-0c1c-416e-9c88-d9c6886c3539.png)

##### Build time (build only)
* x86_64: 43m15s
* arm64: 1h13m13s

##### Build size (compressed CI artifact)
* x86_64: 12.8 MB
* arm64: 15.3 MB
* universal: 19.2 MB

##### Build size (uncompressed)
* x86_64: 62.0 MB
* arm64: 78.1 MB
* universal: 100 MB

That's roughly 54% of the original build time (~46% reduction) for x86_64 and 76% for arm64 (24% reduction). Build sizes have been reduced to between roughly 68% and 78% of their original sizes (about 22% to 32% reductions).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
