### PR TITLE
Properly support multiple VS versions on Windows

### DIFF
--- a/utils.pwsh/Invoke-DevShell.ps1
+++ b/utils.pwsh/Invoke-DevShell.ps1
@@ -29,9 +29,11 @@ function Invoke-DevShell {
         . $PSScriptRoot/Logger.ps1
     }
 
-    if ( ! ( Test-Path variable:VisualStudioData ) ) {
-        $VisualStudioData = Get-CimInstance MSFT_VSInstance
+    if ( ! ( Test-Path function:Find-VisualStudio ) ) {
+        . $PSScriptRoot/Setup-Target.ps1
     }
+
+    $VisualStudioData = Find-VisualStudio
 
     $DevShellCommand =
 @"

--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -78,6 +78,10 @@ function Find-VisualStudio {
 
     $VisualStudioData = Get-CimInstance MSFT_VSInstance
 
+    if ( $VisualStudioData.GetType() -eq [object[]] ) {
+        $VisualStudioData = ($VisualStudioData | Where-Object {$_.Version -ge 16} | Sort-Object -Property Version)[0]
+    }
+
     if ( ! ( $VisualStudioData ) -or ( $VisualStudioData.Version -lt 16 ) ) {
         $ErrorMessage = @(
             "A Visual Studio installation (2019 or newer) is required for this build script.",


### PR DESCRIPTION
### Description

After failing to build obs-deps on Windows, coordinated with @PatTheMav to find a solution that'd fix building.

If multple copies of VIsual Studio are detected, sort the list and choose the oldest version installed.

### Motivation and Context

If more than one copy of Visual Studio is installed, `MSFT_VSInstance` will return an array of objects, causing the rest of the build script to fail.

Additionally, detours failed to build as it bypassed the Find-VisualStudio function, resulting it bypassing the included fix.

### How Has This Been Tested?

* Attempt to build obs-deps on a machine where more than one version/copy of Visual Studio is installed.
* Tested with 2019 and 2022 installed. With these changes, 2019 is selected.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
