### PR TITLE
libpng: Fix shared library being shipped with macOS dependencies

### DIFF
--- a/deps.macos/50-libpng.zsh
+++ b/deps.macos/50-libpng.zsh
@@ -10,6 +10,9 @@ local patches=(
   fb8a209b466e8b2d9eba4c11f776412657b43386ef5db846dd1cc1476556aaa9"
 )
 
+## Dependency Overrides
+local -i force_static=1
+
 ## Build Steps
 setup() {
   log_info "Setup (%F{3}${target}%f)"
@@ -49,13 +52,18 @@ patch() {
 config() {
   autoload -Uz mkcd progress
 
+  if (( shared_libs )) {
+    local shared=$(( shared_libs - force_static ))
+  } else {
+    local shared=0
+  }
   local _onoff=(OFF ON)
 
   args=(
     ${cmake_flags}
     -DPNG_TESTS=OFF
     -DPNG_STATIC=ON
-    -DPNG_SHARED="${_onoff[(( shared_libs + 1 ))]}"
+    -DPNG_SHARED="${_onoff[(( shared + 1 ))]}"
   )
 
   if [[ "${config}" == "Debug" ]] {


### PR DESCRIPTION
### Description
Fixes libpng being shipped as a dynamic library with obs-deps on macOS.

### Motivation and Context
libpng is just needed for FFmpeg and freetype as a static library. As the non-FFmpeg-deps are built as shared libraries, libpng got built as a shared library as well and thus shipped with the package.

This commit forces libpng to be built as a static library, so freetype can pick it up, but it will be removed before packaging.

### How Has This Been Tested?
Tested in local obs-deps build runs on macOS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
