### PR TITLE
CI: Fix name of the generated Qt artifact added to release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,7 +283,7 @@ jobs:
 
           target='${{ matrix.target }}'
           artifact_name="qt-${target}-${{ github.sha }}"
-          file_name="${target%%-*}-qt-$(date +"%Y-%m-%d")-${target##*-}.tar.xz"
+          file_name="${target%%-*}-deps-qt-$(date +"%Y-%m-%d")-${target##*-}.tar.xz"
 
           echo "::set-output name=artifactName::${artifact_name}"
           echo "::set-output name=artifactFileName::${file_name}"

--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -71,7 +71,11 @@ run_stages() {
 
 package() {
   autoload -Uz log_info log_status
-  local filename="${target%%-*}-${PACKAGE_NAME}-${current_date}-${target_config[arch]}.tar.xz"
+  if [[ ${PACKAGE_NAME} == 'qt'* ]] {
+    local filename="${target%%-*}-deps-${PACKAGE_NAME}-${current_date}-${target_config[arch]}.tar.xz"
+  } else {
+    local filename="${target%%-*}-${PACKAGE_NAME}-${current_date}-${target_config[arch]}.tar.xz"
+  }
 
   pushd ${PWD}
   cd ${target_config[output_dir]}


### PR DESCRIPTION
### Description
Fix obs-studio build scripts failing due to misnamed qt release artefacts.

### Motivation and Context
Current obs-studio build scripts expect Qt artifacts to be named `macos-deps-qt-...` - to avoid a breaking change, this commit restores this naming convention.

### How Has This Been Tested?
Built qt artefact locally on macOS machine.

Note that this will require a release run on another fork to check release creation, will undraft PR if this has been confirmed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
