### PR TITLE
utils.pwsh: Support all Get-FileHash algorithms

### DIFF
--- a/utils.pwsh/Invoke-SafeWebRequest.ps1
+++ b/utils.pwsh/Invoke-SafeWebRequest.ps1
@@ -39,8 +39,15 @@ function Invoke-SafeWebRequest {
     try {
         $HashData = Import-Clixml $HashFile
 
+        $SupportedAlgorithms = @("SHA1", "SHA256", "SHA384", "SHA512", "MD5")
+        if ( $HashData.Algorithm -and $SupportedAlgorithms.Contains($HashData.Algorithm) ) {
+            $Algorithm = $HashData.Algorithm
+        } else {
+            $Algorithm = "SHA256"
+        }
+
         if ( ( $CheckExisting ) -and ( Test-Path $OutFile ) ) {
-            $NewHash = Get-FileHash -Path $OutFile -Algorithm SHA256
+            $NewHash = Get-FileHash -Path $OutFile -Algorithm $Algorithm
         } else {
             $WebRequestParams = @{
                 UserAgent = "NativeHost"
@@ -56,7 +63,7 @@ function Invoke-SafeWebRequest {
 
             Invoke-WebRequest @WebRequestParams
 
-            $NewHash = Get-FileHash -Path $OutFile -Algorithm SHA256
+            $NewHash = Get-FileHash -Path $OutFile -Algorithm $Algorithm
         }
     } catch {
         throw "Error while downloading ${Uri}: ${PSItem}."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Get-FileHash supports the following hash algorithms:
 * SHA1
 * SHA256
 * SHA384
 * SHA512
 * MD5

Let's support all of those instead of hard-coding SHA256 only for downloading files via Invoke-SafeWebRequest.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
More easily check hashsums if projects did not provide SHA256, but did provide hashes from another supported algorithm.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Manually tested locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
