### PR TITLE
Add Qt Windows builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
 /licenses/** -text
+/**/patches/** -text

--- a/.github/actions/build-windows-qt/action.yml
+++ b/.github/actions/build-windows-qt/action.yml
@@ -1,0 +1,57 @@
+name: 'Build Windows Qt'
+description: 'Builds Windows Qt for obs-deps with specified architecture and build config'
+inputs:
+  qtVersion:
+    description: 'Qt version to build'
+    required: false
+    default: '5'
+  target:
+    description: 'Build target for Qt'
+    required: true
+  config:
+    description: 'Build configuration'
+    required: false
+    default: 'Release'
+  cacheRevision:
+    description: 'Cache revision number to force creation of new cache generation'
+    required: false
+    default: '01'
+runs:
+  using: 'composite'
+  steps:
+    - name: Environment Setup
+      id: qt-env-setup
+      shell: pwsh
+      run: |
+        $QtDepHash = (Get-FileHash -Path "${{ github.workspace }}/deps.qt/qt${{ inputs.qtVersion }}.ps1" -Algorithm "SHA256").Hash
+        if ( Test-Path "${{ github.workspace }}/deps.qt/patches/Qt${{ inputs.qtVersion }}" ) {
+          $QtPatchHash = (Get-FileHash "${{ github.workspace }}/deps.qt/patches/Qt${{ inputs.qtVersion }}/win/0001-QTBUG-74606.patch" -Algorithm "SHA256").Hash
+        } else {
+          $QtPatchHash = "nopatches"
+        }
+
+        Write-Output "::set-output name=depHash::${QtDepHash}"
+        Write-Output "::set-output name=patchHash::${QtPatchHash}"
+
+    - name: Restore Windows Qt from Cache
+      id: deps-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ github.workspace }}/*_build_temp/qt${{ inputs.qtVersion }}*
+          !${{ github.workspace }}/*_build_temp/**/.git
+          !${{ github.workspace }}/*_build_temp/*.tar.gz
+          !${{ github.workspace }}/*_build_temp/*.tar.xz
+          !${{ github.workspace }}/*_build_temp/*.zip
+        key: ${{ inputs.target }}-windows-qt${{ inputs.qtVersion }}-${{inputs.config }}-${{ steps.qt-env-setup.outputs.depHash }}-${{ inputs.cacheRevision }}-${{ steps.qt-env-setup.outputs.patchHash }}
+        restore-keys: ${{ inputs.target }}-windows-qt${{ inputs.qtVersion }}-${{inputs.config }}-${{ steps.qt-env-setup.outputs.depHash }}-${{ inputs.cacheRevision }}-
+
+    - name: Install Windows Qt
+      if: ${{ steps.deps-cache.outputs.cache-hit == 'true' }}
+      shell: pwsh
+      run: ./Build-Dependencies.ps1 -Dependencies "Qt${{ inputs.qtVersion }}" -SkipBuild -SkipUnpack -Target ${{ inputs.target }} -Configuration ${{ inputs.config }} -Shared
+
+    - name: Build and Install Windows Qt
+      if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
+      shell: pwsh
+      run: ./Build-Dependencies.ps1 -Dependencies "Qt${{ inputs.qtVersion }}"  -Target ${{ inputs.target }} -Configuration ${{ inputs.config }} -Shared

--- a/.github/actions/package-windows-qt/action.yml
+++ b/.github/actions/package-windows-qt/action.yml
@@ -1,0 +1,88 @@
+name: 'Package Windows Qt'
+description: 'Packages Windows Qt for obs-deps with specified architecture'
+inputs:
+  base:
+    description: 'Base name of the Windows artifacts to download'
+    required: true
+  outputName:
+    description: 'Name pattern for created Windows artifacts'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Download Windows RelWithDebInfo artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.base }}-RelWithDebInfo-${{ github.sha }}
+
+    - name: Get File Names
+      id: GetFileNames
+      shell: pwsh
+      run: |
+        $FileName = (Get-ChildItem -Filter "windows-deps-qt*.zip").Name.Replace("-RelWithDebInfo", "")
+        $PDBArchiveFileName = (Get-ChildItem -Filter "windows-deps-qt*.zip").Name.Replace("RelWithDebInfo", "ReleasePDBs")
+        $PDBOutputName = "${{ inputs.outputName }}".Replace("${{ inputs.base }}", "${{ inputs.base }}-ReleasePDBs")
+        Write-Output "::set-output name=fileName::${FileName}"
+        Write-Output "::set-output name=pdbFileName::${PDBArchiveFileName}"
+        Write-Output "::set-output name=pdbOutputName::${PDBOutputName}"
+
+    - name: Extract RelWithDebInfo
+      shell: pwsh
+      run: |
+        7z x 'windows-deps-qt*.zip' -oqt_rel
+        Remove-Item "*.zip"
+
+    - name: Separate RelWithDebInfo PDBs
+      shell: pwsh
+      run: |
+        New-Item -ItemType "directory" rel_pdbs
+        Set-Location "qt_rel"
+        $QtInstallDir = (Get-Location | Convert-Path)
+        Set-Location "..\rel_pdbs"
+        $ReleasePdbInstallDir = (Get-Location | Convert-Path)
+        Set-Location ".."
+        $ReleasePdbFiles = Get-ChildItem -Filter "*.pdb" -File -Recurse
+        $DestinationDirRelativePaths = ( $ReleasePdbFiles | ForEach-Object { $_.DirectoryName } | Sort-Object -Unique ).Replace("${QtInstallDir}\", "")
+        $DestinationDirRelativePaths | ForEach-Object { New-Item -Name "$_" -Path "${ReleasePdbInstallDir}" -ItemType "directory" -Force }
+        $ReleasePdbFiles | ForEach-Object { Move-Item $_.FullName $_.FullName.Replace("${QtInstallDir}", "${ReleasePdbInstallDir}") }
+
+    - name: Download Windows Debug artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.base }}-Debug-${{ github.sha }}
+
+    - name: Extract Debug
+      shell: pwsh
+      run: |
+        7z x 'windows-deps-qt*.zip' -oqt
+        Remove-Item "*.zip"
+
+    - name: Copy RelWithDebInfo over Debug
+      shell: pwsh
+      run: |
+        Remove-Item -Path "qt" -Include "cmake_automoc_parser.*","moc.*","qlalr.*","qmake.*","qsb.*","qtpaths.*","qvkgen.*","rcc.*","tracegen.*","uic.*" -Recurse
+        Copy-Item "qt_rel\*" "qt\" -Recurse -Force
+
+    - name: Create combined Qt archive
+      shell: pwsh
+      run: |
+        $FileName = "${{ steps.GetFileNames.outputs.fileName }}"
+        7z a "$FileName" .\qt\* -mx=9
+
+    - name: Create Release PDBs archive
+      shell: pwsh
+      run: |
+        $FileName = "${{ steps.GetFileNames.outputs.pdbFileName }}"
+        7z a "$FileName" .\rel_pdbs\* -mx=9
+
+    - name: Publish Combined Qt Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.outputName }}
+        path: ${{ github.workspace }}/${{ steps.GetFileNames.outputs.fileName }}
+
+    - name: Publish Release PDBs Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.GetFileNames.outputs.pdbOutputName }}
+        path: ${{ github.workspace }}/${{ steps.GetFileNames.outputs.pdbFileName }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -529,11 +529,108 @@ jobs:
           name: ${{ steps.setup.outputs.artifactName }}
           path: ${{ github.workspace }}\windows\${{ steps.setup.outputs.artifactFileName }}
 
+  windows-qt-build:
+    name: 'Build Windows Qt'
+    runs-on: windows-2019
+    strategy:
+      fail-fast: true
+      matrix:
+        qtVersion: [5, 6]
+        target: [x64, x86]
+        config: ['RelWithDebInfo', 'Debug']
+    env:
+      CACHE_REVISION: '01'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Environment
+        id: setup
+        run: |
+          $ArtifactName="qt${{ matrix.qtVersion }}-windows-${{ matrix.target }}-${{ matrix.config }}-${{ github.sha }}"
+          $FileName="windows-deps-qt${{ matrix.qtVersion }}-$(Get-Date -Format 'yyyy-MM-dd')-${{ matrix.target }}-${{ matrix.config }}.zip"
+
+          Write-Output "::set-output name=artifactName::${ArtifactName}"
+          Write-Output "::set-output name=artifactFileName::${FileName}"
+
+      - name: 'Check for GitHub Labels'
+        id: seekingTesters
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          $LabelFound = try {
+            $Params = @{
+              Authentication = 'Bearer'
+              Token = (ConvertTo-SecureString '${{ secrets.GITHUB_TOKEN }}' -AsPlainText)
+              Uri = '${{ github.event.pull_request.url }}'
+              UseBasicParsing = $true
+            }
+
+            (Invoke-RestMethod @Params).labels.name.contains("Seeking Testers")
+          } catch {
+            $false
+          }
+
+          Write-Output "::set-output name=found::$(([string]${LabelFound}).ToLower())"
+
+      - name: 'Build Windows Qt'
+        uses: ./.github/actions/build-windows-qt
+        with:
+          target: ${{ matrix.target }}
+          config: ${{ matrix.config }}
+          qtVersion: ${{ matrix.qtVersion }}
+          cacheRevision: ${{ env.CACHE_REVISION }}
+
+      - name: 'Publish Build Artifacts'
+        if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.setup.outputs.artifactName }}
+          path: ${{ github.workspace }}/windows/${{ steps.setup.outputs.artifactFileName }}
+
+  windows-qt-package:
+    name: 'Package Windows Qt (${{ matrix.qtVersion }}, ${{ matrix.target }})'
+    runs-on: windows-2019
+    strategy:
+      fail-fast: true
+      matrix:
+        qtVersion: [5, 6]
+        target: [x64, x86]
+    needs: [windows-qt-build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: 'Check for GitHub Labels'
+        id: seekingTesters
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          $LabelFound = try {
+            $Params = @{
+              Authentication = 'Bearer'
+              Token = (ConvertTo-SecureString '${{ secrets.GITHUB_TOKEN }}' -AsPlainText)
+              Uri = '${{ github.event.pull_request.url }}'
+              UseBasicParsing = $true
+            }
+
+            (Invoke-RestMethod @Params).labels.name.contains("Seeking Testers")
+          } catch {
+            $false
+          }
+
+          Write-Output "::set-output name=found::$(([string]${LabelFound}).ToLower())"
+
+      - name: Create Windows Qt package
+        if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
+        uses: ./.github/actions/package-windows-qt
+        with:
+          base: 'qt${{ matrix.qtVersion }}-windows-${{ matrix.target }}'
+          outputName: 'qt${{ matrix.qtVersion }}-windows-${{ matrix.target }}-${{ github.sha }}'
+
   make-release:
     name: 'Create and upload release'
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: [ffmpeg-package-universal, macos-package-universal, macos-qt5-package-universal, macos-qt6-package, windows-build]
+    needs: [ffmpeg-package-universal, macos-package-universal, macos-qt5-package-universal, macos-qt6-package, windows-build, windows-qt-package]
     defaults:
       run:
         shell: bash
@@ -555,7 +652,7 @@ jobs:
             _temp=$(mktemp -d)
             pushd "${_temp}" > /dev/null
 
-            for artifact in ${{ github.workspace }}/**/windows-*-${arch}.*; do
+            for artifact in ${{ github.workspace }}/**/windows-@(deps|ffmpeg)-!(qt5*|qt6*)-${arch}.*; do
               case ${artifact} in
                 *.zip) unzip ${artifact} > /dev/null ;;
                 *.tar.xz) XZ_OPT=-T0 tar -xJf ${artifact} ;;
@@ -565,6 +662,9 @@ jobs:
 
             zip -r windows-deps-${{ steps.metadata.outputs.version }}-${arch}.zip -- *
             mv windows-deps-${{ steps.metadata.outputs.version }}-${arch}.zip ${{ github.workspace }}
+
+            mv ${{ github.workspace }}/qt5-windows-${arch}-!(RelWithDebInfo*|Debug*)/*.zip ${{ github.workspace }}
+            mv ${{ github.workspace }}/qt6-windows-${arch}-!(RelWithDebInfo*|Debug*)/*.zip ${{ github.workspace }}
 
             popd > /dev/null
           done
@@ -634,8 +734,8 @@ jobs:
           name: "OBS Deps Build ${{ steps.metadata.outputs.version }}"
           body_path: ${{ github.workspace }}/CHECKSUMS.txt
           files: |
-            ${{ github.workspace }}/windows-*-x64.zip
-            ${{ github.workspace }}/windows-*-x86.zip
+            ${{ github.workspace }}/windows-*-x64*.zip
+            ${{ github.workspace }}/windows-*-x86*.zip
             ${{ github.workspace }}/macos-*-arm64.tar.xz
             ${{ github.workspace }}/macos-*-x86_64.tar.xz
             ${{ github.workspace }}/macos-*-universal.tar.xz

--- a/deps.qt/checksums/jom-1.1.3.zip.sha256
+++ b/deps.qt/checksums/jom-1.1.3.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">128FDD846FE24F8594EED37D1D8929A0EA78DF563537C0C1B1861A635013FFF8</S>
+      <S N="Path">jom_1_1_3.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.qt/patches/Qt5/win/0001-QTBUG-74606.patch
+++ b/deps.qt/patches/Qt5/win/0001-QTBUG-74606.patch
@@ -1,0 +1,13 @@
+--- ./qtbase/src/widgets/kernel/qwidgetwindow.cpp 2020-10-27 09:02:11.000000000 +0100
++++ ./qtbase/src/widgets/kernel/qwidgetwindow.cpp 2021-06-12 16:20:04.000000000 +0200
+@@ -252,10 +252,7 @@
+     switch (event->type()) {
+     case QEvent::Close: {
+         // The widget might be deleted in the close event handler.
+-        QPointer<QObject> guard = this;
+         handleCloseEvent(static_cast<QCloseEvent *>(event));
+-        if (guard)
+-            QWindow::event(event);
+         return true;
+     }
+ 

--- a/deps.qt/qt5.ps1
+++ b/deps.qt/qt5.ps1
@@ -1,0 +1,147 @@
+param(
+    [string] $Name = 'qt5',
+    [string] $Version = '5.15.2',
+    [string] $Uri = 'https://github.com/qt/qt5.git',
+    [string] $Hash = '9b43a43ee96198674060c6b9591e515e2d27c28f',
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/Qt5/win/0001-QTBUG-74606.patch"
+            HashSum = "BAE8765FC74FB398BC3967AD82760856EE308E643A8460C324D36A4D07063001"
+        }
+    )
+)
+
+# References:
+# 1: https://wiki.qt.io/Building_Qt_5_from_Git
+# 2: https://doc.qt.io/qt-5/windows-building.html
+# 3: https://doc.qt.io/qt-5/configure-options.html#source-build-and-install-directories
+# 4: https://doc.qt.io/qt-6.2/windows-building.html
+
+# Per [2]:
+# Note: The install path must not contain any spaces or Windows specific file system characters.
+
+# Per [4]:
+# Note: The path to the source directory must not contain any spaces or Windows specific file system characters. The
+# path should also be kept short. This avoids issues with too long file paths in the compilation phase.
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+
+    # Download jom if not present and check its hash.
+    Invoke-SafeWebRequest -Uri "https://download.qt.io/official_releases/jom/jom_1_1_3.zip" -HashFile "${PSScriptRoot}/checksums/jom-1.1.3.zip.sha256" -CheckExisting
+    Expand-ArchiveExt -Path "jom_1_1_3.zip" -DestinationPath "jom" -Force
+
+    New-Item -ItemType "directory" -Path "qt5_build\${Version}\${Target}" -Force
+    New-Item -ItemType "directory" -Path "$($ConfigData.OutputPath)" -Force
+
+    # Run init-repository perl script.
+    # This will fail if any of the repos are dirty (uncommitted patches).
+    Set-Location qt5
+
+    # Perform git clean here to ensure that init-repository does not fail.
+    Invoke-External git submodule foreach --recursive "git clean -dfx"
+    Invoke-External git clean -dfx
+
+    Check-GitUser
+    $Options = @(
+        '--module-subset', 'qtbase,qtimageformats,qtmultimedia,qtsvg,qtwinextras'
+        '--force'
+    )
+    Invoke-External perl init-repository @Options
+}
+
+function Clean {
+    Set-Location $Path
+
+    # Perform git clean here to ensure that the source tree is clean.
+    # This should only be needed if building in-tree, but safe enough to do either way.
+    Invoke-External git submodule foreach --recursive "git clean -dfx"
+    Invoke-External git clean -dfx
+
+    Set-Location ".."
+    Remove-Item "qt5_build\${Version}\${Target}\*" -Recurse -Force
+    Remove-Item "$($ConfigData.OutputPath)\*" -Recurse -Force
+}
+
+function Patch {
+    Log-Information "Patch (${Target})"
+    Set-Location $Path
+
+    $Patches | ForEach-Object {
+        $Params = $_
+        Safe-Patch @Params
+    }
+
+    Set-Location qtbase
+    Check-GitUser
+    git add .
+    git commit -m "Simple fix for QTBUG-74606"
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $BuildPath = "$($ConfigData.OutputPath)"
+    Set-Location "..\qt5_build\${Version}\${Target}"
+
+    $QtBuildConfiguration = '-release'
+    if ( $Configuration -eq 'Release' ) {
+        $QtBuildConfiguration = '-release'
+    } elseif ( $Configuration -eq 'RelWithDebInfo' ) {
+        $QtBuildConfiguration = '-release -force-debug-info'
+    } elseif ( $Configuration -eq 'Debug' ) {
+        $QtBuildConfiguration = '-debug'
+    } elseif ( $Configuration -eq 'MinSizeRel' ) {
+        $QtBuildConfiguration = '-release'
+    }
+
+    $BuildCommand = "..\..\..\qt5\configure -opensource -confirm-license ${QtBuildConfiguration} -no-strip -nomake examples -nomake tests -no-compile-examples -schannel -no-dbus -no-freetype -no-harfbuzz -no-icu -no-feature-itemmodeltester -no-feature-printdialog -no-feature-printer -no-feature-printpreviewdialog -no-feature-printpreviewwidget -no-feature-sql -no-feature-sqlmodel -no-feature-testlib -no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc -no-sql-psql -no-sql-sqlite2 -no-sql-sqlite -no-sql-tds -DQT_NO_PDF -DQT_NO_PRINTER -mp -prefix ${BuildPath}"
+
+    $Params = @{
+        BasePath = (Get-Location | Convert-Path)
+        BuildPath = "."
+        BuildCommand = "${BuildCommand}"
+        Target = $Target
+        HostArchitecture = $Target
+    }
+
+    Invoke-DevShell @Params
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    Set-Location ".."
+    Copy-Item "jom\jom.exe" "qt5_build\${Version}\${Target}\jom.exe"
+
+    Set-Location "qt5_build\${Version}\${Target}"
+
+    $Params = @{
+        BasePath = (Get-Location | Convert-Path)
+        BuildPath = "."
+        BuildCommand = ".\jom.exe"
+        Target = $Target
+        HostArchitecture = $Target
+    }
+
+    Invoke-DevShell @Params
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    Set-Location "..\qt5_build\${Version}\${Target}"
+
+    $Params = @{
+        BasePath = (Get-Location | Convert-Path)
+        BuildPath = "."
+        BuildCommand = ".\jom.exe install"
+        Target = $Target
+        HostArchitecture = $Target
+    }
+
+    Invoke-DevShell @Params
+}

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -1,0 +1,127 @@
+param(
+    [string] $Name = 'qt6',
+    [string] $Version = '6.3',
+    [string] $Uri = 'https://github.com/qt/qt5.git',
+    [string] $Hash = '9af3e106a7bb6bd4ed2b8c4d31a8d6090a582b02'
+)
+
+# References:
+# 1: https://wiki.qt.io/Building_Qt_6_from_Git
+# 2: https://doc.qt.io/qt-6/windows-building.html
+# 3: https://doc.qt.io/qt-6/configure-options.html#source-build-and-install-directories
+# 4: https://doc.qt.io/qt-6.2/windows-building.html
+
+# Per [2]:
+# Note: The install path must not contain any spaces or Windows specific file system characters.
+
+# Per [4]:
+# Note: The path to the source directory must not contain any spaces or Windows specific file system characters. The
+# path should also be kept short. This avoids issues with too long file paths in the compilation phase.
+
+function Setup {
+    Check-Ninja
+    $Path = "qt6"
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath "$Path"
+
+    New-Item -ItemType "directory" -Path "qt6_build\${Version}\${Target}" -Force
+    New-Item -ItemType "directory" -Path "$($ConfigData.OutputPath)" -Force
+
+    # Run init-repository perl script.
+    # This will fail if any of the repos are dirty (uncommitted patches).
+    Set-Location qt6
+    $Options = @(
+        '--module-subset', 'qtbase,qtimageformats,qtmultimedia,qtshadertools,qtsvg'
+        '--force'
+    )
+    Invoke-External perl init-repository @Options
+}
+
+function Clean {
+    Set-Location $Path
+
+    # Perform git clean here to ensure that the source tree is clean.
+    # This should only be needed if building in-tree, but safe enough to do either way.
+    Invoke-External git submodule foreach --recursive "git clean -dfx"
+    Invoke-External git clean -dfx
+
+    Set-Location ".."
+    Remove-Item "qt6_build\${Version}\${Target}\*" -Recurse -Force
+    Remove-Item "$($ConfigData.OutputPath)\*" -Recurse -Force
+}
+
+function Patch {
+    Log-Information "Patch (${Target})"
+    Set-Location $Path
+
+    $Patches | ForEach-Object {
+        $Params = $_
+        Safe-Patch @Params
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $BuildPath = "$($ConfigData.OutputPath)"
+    Set-Location "..\qt6_build\${Version}\${Target}"
+
+    $QtBuildConfiguration = '-release'
+    if ( $Configuration -eq 'Release' ) {
+        $QtBuildConfiguration = '-release'
+    } elseif ( $Configuration -eq 'RelWithDebInfo' ) {
+        $QtBuildConfiguration = '-release -force-debug-info'
+    } elseif ( $Configuration -eq 'Debug' ) {
+        $QtBuildConfiguration = '-debug'
+    } elseif ( $Configuration -eq 'MinSizeRel' ) {
+        $QtBuildConfiguration = '-release'
+    }
+
+    $BuildCommand = "..\..\..\qt6\configure -opensource -confirm-license ${QtBuildConfiguration} -nomake examples -nomake tests -schannel -no-dbus -no-freetype -no-icu -no-openssl -no-feature-androiddeployqt -no-feature-pdf -no-feature-printsupport -no-feature-qmake -no-feature-sql -no-feature-testlib -no-feature-windeployqt -DQT_NO_PDF -prefix ${BuildPath}"
+
+    $Params = @{
+        BasePath = (Get-Location | Convert-Path)
+        BuildPath = "."
+        BuildCommand = "${BuildCommand}"
+        Target = $Target
+        HostArchitecture = $Target
+    }
+
+    Invoke-DevShell @Params
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    Set-Location "..\qt6_build\${Version}\${Target}"
+
+    $Params = @{
+        BasePath = (Get-Location | Convert-Path)
+        BuildPath = "."
+        BuildCommand = "cmake --build . --parallel"
+        Target = $Target
+        HostArchitecture = $Target
+    }
+
+    Invoke-DevShell @Params
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    Set-Location "..\qt6_build\${Version}\${Target}"
+
+    $BuildCommand = 'cmake --install .'
+
+    $Params = @{
+        BasePath = (Get-Location | Convert-Path)
+        BuildPath = "."
+        BuildCommand = "${BuildCommand}"
+        Target = $Target
+        HostArchitecture = $Target
+    }
+
+    Invoke-DevShell @Params
+}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add Qt 5 and Qt 6 builds for Windows 32-bit and 64-bit with both RelWithDebInfo and Debug configurations. This also adds Release PDBs to the Qt builds and offers them as a separate release asset on releases.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We want to provide an easy way to build Qt locally and on CI in the same configuration that we use regularly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have run and re-run these build scripts locally and on my fork's CI. I have also tested the release job on my fork. I have built OBS Studio against artifacts from these runs locally by updating the Qt version for the Windows build scripts.

The one caveat I've found is that we get some new LNK4099 warnings in MSVC (expected a PDB file for a library, but PDB not found) due to building Qt in Release but with PDBs, instead of building in `-debug-and-release` mode, where "release" is just "Release" without PDBs.

To build Qt 5, one should run:
```
.\Build-Dependencies.ps1 -Dependencies "Qt5"
```
To build Qt 6, one should run:
```
.\Build-Dependencies.ps1 -Dependencies "Qt6"
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
