### PR TITLE
windows-deps: Add patched swig binary with support for Py3 stable ABI

### DIFF
--- a/Build-Dependencies.ps1
+++ b/Build-Dependencies.ps1
@@ -114,6 +114,26 @@ function Package-Dependencies {
     Push-Location -Stack BuildTemp
     Set-Location $ConfigData.OutputPath
 
+    Log-Information "Cleanup unnecessary files"
+    $Items = @(
+        "./bin/bison.exe"
+        "./bin/libiconv2.dll"
+        "./bin/libintl3.dll"
+        "./bin/m4.exe"
+        "./bin/pcre2*"
+        "./bin/regex2.dll"
+        "./cmake/pcre2*"
+        "./include/pcre2*"
+        "./lib/pcre2*"
+        "./lib/pkgconfig/libpcre2*"
+        "./man1/pcre2*"
+        "./man3/pcre2*"
+        "./share/bison"
+        "./share/doc/pcre2"
+    )
+
+    Remove-Item -ErrorAction 'SilentlyContinue' -Path $Items -Force -Recurse
+
     Log-Information "Package dependencies"
 
     $Params = @{

--- a/deps.windows/50-bison-bin.ps1
+++ b/deps.windows/50-bison-bin.ps1
@@ -1,0 +1,46 @@
+param(
+    [string] $Name = 'bison',
+    [string] $Version = '2.4.1',
+    [string] $Uri = 'http://downloads.sourceforge.net/gnuwin32/bison-2.4.1-bin.zip',
+    [string] $Hash = "${PSScriptRoot}/checksums/bison-2.4.1-bin.zip.sha256"
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    New-Item -Path "$($ConfigData.OutputPath)/bin" -ItemType Directory -Force *> $null
+
+    $Items = @(
+        @{
+            Path = './bin/bison.exe'
+            Destination = "$($ConfigData.OutputPath)/bin/bison.exe"
+            ErrorAction = 'SilentlyContinue'
+            Recurse = $true
+        },
+        @{
+            Path = './bin/m4.exe'
+            Destination = "$($ConfigData.OutputPath)/bin/m4.exe"
+            ErrorAction = 'SilentlyContinue'
+            Recurse = $true
+        },
+        @{
+            Path = './share/bison'
+            Destination = "$($ConfigData.OutputPath)/share/bison"
+            ErrorAction = 'SilentlyContinue'
+            Recurse = $true
+        }
+    )
+
+    $Items | ForEach-Object {
+        $Item = $_
+        Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
+        Copy-Item @Item
+    }
+
+    $env:M4 = "$($ConfigData.OutputPath)/bin/m4.exe"
+}

--- a/deps.windows/50-bison-dep.ps1
+++ b/deps.windows/50-bison-dep.ps1
@@ -1,0 +1,32 @@
+param(
+    [string] $Name = 'bison',
+    [string] $Version = '2.4.1',
+    [string] $Uri = 'http://downloads.sourceforge.net/gnuwin32/bison-2.4.1-dep.zip',
+    [string] $Hash = "${PSScriptRoot}/checksums/bison-2.4.1-dep.zip.sha256"
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    New-Item -Path "$($ConfigData.OutputPath)/bin" -ItemType Directory -Force *> $null
+
+    $Items = @(
+        @{
+            Path = './bin/*.dll'
+            Destination = "$($ConfigData.OutputPath)/bin/"
+            ErrorAction = 'SilentlyContinue'
+            Recurse = $true
+        }
+    )
+
+    $Items | ForEach-Object {
+        $Item = $_
+        Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
+        Copy-Item @Item
+    }
+}

--- a/deps.windows/50-pcre.ps1
+++ b/deps.windows/50-pcre.ps1
@@ -1,0 +1,63 @@
+param(
+    [string] $Name = 'pcre',
+    [string] $Version = '10.40',
+    [string] $Uri = 'https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.40/pcre2-10.40.zip',
+    [string] $Hash = "${PSScriptRoot}/checksums/pcre2-10.40.zip.sha256"
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Clean {
+    Set-Location $Path
+
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location "${Path}/$([System.IO.Path]::GetFileNameWithoutExtension($Uri))"
+
+    $Options = @(
+        $CmakeOptions
+        "-DBUILD_SHARED_LIBS=OFF"
+    )
+
+    Invoke-External cmake -S . -B "build_${Target}" @Options
+}
+
+function Build {
+    Log-Information "Install (${Target})"
+    Set-Location "${Path}/$([System.IO.Path]::GetFileNameWithoutExtension($Uri))"
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location "${Path}/$([System.IO.Path]::GetFileNameWithoutExtension($Uri))"
+
+    $Options = @(
+        '--install', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $Configuration -match "(Release|MinSizeRel)" ) {
+        $Options += '--strip'
+    }
+
+    Invoke-External cmake @Options
+}

--- a/deps.windows/50-swig.ps1
+++ b/deps.windows/50-swig.ps1
@@ -1,34 +1,109 @@
 param(
     [string] $Name = 'swig',
-    [string] $Version = '3.0.12',
-    [string] $Uri = 'https://downloads.sourceforge.net/project/swig/swigwin/swigwin-3.0.12/swigwin-3.0.12.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/swigwin-3.0.12.zip.sha256"
+    [string] $Version = '4.1.0',
+    [string] $Uri = 'https://github.com/swig/swig.git',
+    [string] $Hash = "4dd285fad736c014224ef2ad25b85e17f3dce1f9",
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/swig/0001-add-Python-3-stable-abi.patch"
+            HashSum = '0fba519582d891a01953fd81f4e91ddd583f32cab398436df5632d98e0060309'
+        },
+        @{
+            PatchFile = "${PSScriptRoot}/patches/swig/0002-remove-PCRE-cmake-finder.patch"
+            HashSum = 'fc11c4493bf8857a38bd52e76586112a95c286a9059d84216c3e963d3cf103b3'
+        }
+    )
 )
 
 function Setup {
     Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
 }
 
+function Clean {
+    Set-Location $Path
+
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Patch {
+    Log-Information "Patch (${Target})"
+    Set-Location $Path
+
+    $Patches | ForEach-Object {
+        $Params = $_
+        Safe-Patch @Params
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $Options = $CmakeOptions
+
+    Invoke-External cmake -S . -B "build_${Target}" @Options
+
+    if ( $env:M4 -eq '' ) {
+        $env:M4 = "$($ConfigData.OutputPath)/bin/m4.exe"
+    }
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
 function Install {
     Log-Information "Install (${Target})"
     Set-Location $Path
 
-    Remove-Item "swigwin-${Version}/Examples", "swigwin-${Version}/Doc" -Recurse -Force -ErrorAction 'SilentlyContinue'
+    $Options = @(
+        '--install', "build_${Target}"
+        '--config', $Configuration
+        '--prefix', "$($ConfigData.OutputPath)/swig"
+    )
 
-    New-Item -Path "$($ConfigData.OutputPath)/swig" -ItemType Directory -Force *> $null
+    if ( $Configuration -match "(Release|MinSizeRel)" ) {
+        $Options += '--strip'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Fixup {
+    Log-Information "Fixup (${Target})"
 
     $Items = @(
         @{
-            Path = "swigwin-${Version}/*"
-            Destination = "$($ConfigData.OutputPath)/swig"
-            ErrorAction = "SilentlyContinue"
-            Recurse = $true
+            Path = "$($ConfigData.OutputPath)/swig/bin/swig.exe"
+            Destination = "$($ConfigData.OutputPath)/swig/swig.exe"
+        },
+        @{
+            Path = "$($ConfigData.OutputPath)/swig/share/swig/${Version}"
+            Destination = "$($ConfigData.OutputPath)/swig/Lib"
         }
     )
 
     $Items | ForEach-Object {
         $Item = $_
-        Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
-        Copy-Item @Item
+        Log-Status ('{0} => {1}' -f $Item.Path, $Item.Destination)
+        Move-Item @Item
     }
+
+    Remove-Item "$($ConfigData.OutputPath)/swig/share" -Recurse -ErrorAction 'SilentlyContinue'
+    Remove-Item "$($ConfigData.OutputPath)/swig/bin" -Recurse -ErrorAction 'SilentlyContinue'
 }

--- a/deps.windows/checksums/bison-2.4.1-bin.zip.sha256
+++ b/deps.windows/checksums/bison-2.4.1-bin.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">CD239AB43BAEA53CFDB1F2663AD0883586B97F22CEE825C3780AD9BBA7E6EE19</S>
+      <S N="Path">bison-2.4.1-bin.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.windows/checksums/bison-2.4.1-dep.zip.sha256
+++ b/deps.windows/checksums/bison-2.4.1-dep.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">A69C14F6C9766DB0D2C0F69C6C46598DCE4CE6A3060DE8E20DBC5217D7AD714B</S>
+      <S N="Path">bison-2.4.1-dep.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.windows/checksums/pcre2-10.40.zip.sha256
+++ b/deps.windows/checksums/pcre2-10.40.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">B6EE01732F0E41296E60A00CE37FBED1C4955AE7E7625B1FD29A55605C9493B4</S>
+      <S N="Path">windows_32-bit_build_temp\pcre2-10.40.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.windows/patches/swig/0001-add-Python-3-stable-abi.patch
+++ b/deps.windows/patches/swig/0001-add-Python-3-stable-abi.patch
@@ -1,0 +1,643 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 60791155c..b77e840ca 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -135,6 +135,8 @@ jobs:
+           VER: '3.9'
+         - SWIGLANG: python
+           VER: '3.10'
++        - SWIGLANG: python
++          SWIG_FEATURES: -py3-stable-abi
+         - SWIGLANG: python
+           PY2: 2
+           SWIG_FEATURES: -builtin
+diff --git a/Lib/python/director.swg b/Lib/python/director.swg
+index 9694c6233..7935f7003 100644
+--- a/Lib/python/director.swg
++++ b/Lib/python/director.swg
+@@ -14,6 +14,24 @@
+ #include <vector>
+ #include <map>
+ 
++#if defined(SWIG_PYTHON_THREADS)
++/*  __THREAD__ is the old macro to activate some thread support */
++# if !defined(__THREAD__)
++#   define __THREAD__ 1
++# endif
++#endif
++
++#ifdef __THREAD__
++#ifndef Py_LIMITED_API
++# include "pythread.h"
++#else
++# if defined(_WIN32)
++#   include <windows.h>
++# else
++#   include <pthread.h>
++# endif
++#endif
++#endif
+ 
+ /*
+   Use -DSWIG_PYTHON_DIRECTOR_NO_VTABLE if you don't want to generate a 'virtual
+@@ -244,25 +262,89 @@ namespace Swig {
+   };
+ 
+ 
+-#if defined(SWIG_PYTHON_THREADS)
+-/*  __THREAD__ is the old macro to activate some thread support */
+-# if !defined(__THREAD__)
+-#   define __THREAD__ 1
+-# endif
+-#endif
+-
+ #ifdef __THREAD__
+-# include "pythread.h"
++#ifndef Py_LIMITED_API
++   class Mutex
++   {
++   public:
++       Mutex() {
++           mutex_ = PyThread_allocate_lock();
++       }
++
++       ~Mutex() {
++           PyThread_release_lock(mutex_);
++       }
++
++   private:
++       void Lock() {
++           PyThread_acquire_lock(mutex_, WAIT_LOCK);
++       }
++
++       void Unlock() {
++           PyThread_free_lock(mutex_);
++       }
++
++       PyThread_type_lock mutex_;
++
++       friend class Guard;
++   };
++#elif defined(_WIN32)
++    class Mutex : private CRITICAL_SECTION {
++    public:
++        Mutex() {
++            InitializeCriticalSection(this);
++        }
++
++        ~Mutex() {
++            DeleteCriticalSection(this);
++        }
++
++    private:
++        void Lock() {
++            EnterCriticalSection(this);
++        }
++
++        void Unlock() {
++            LeaveCriticalSection(this);
++        }
++
++        friend class Guard;
++    };
++#else
++    class Mutex {
++    public:
++        Mutex() {
++            pthread_mutex_init(&mutex_, NULL);
++        }
++
++        ~Mutex() {
++            pthread_mutex_destroy(&mutex_);
++        }
++
++    private:
++        void Lock() {
++            pthread_mutex_lock(&mutex_);
++        }
++
++        void Unlock() {
++            pthread_mutex_unlock(&mutex_);
++        }
++
++        friend class Guard;
++
++        pthread_mutex_t mutex_;
++    };
++#endif
+   class Guard {
+-    PyThread_type_lock &mutex_;
++    Mutex &mutex_;
+ 
+   public:
+-    Guard(PyThread_type_lock & mutex) : mutex_(mutex) {
+-      PyThread_acquire_lock(mutex_, WAIT_LOCK);
++    Guard(Mutex & mutex) : mutex_(mutex) {
++      mutex_.Lock();
+     }
+ 
+     ~Guard() {
+-      PyThread_release_lock(mutex_);
++      mutex_.Unlock();
+     }
+   };
+ # define SWIG_GUARD(mutex) Guard _guard(mutex)
+@@ -330,7 +412,7 @@ namespace Swig {
+     typedef std::map<void *, GCItem_var> swig_ownership_map;
+     mutable swig_ownership_map swig_owner;
+ #ifdef __THREAD__
+-    static PyThread_type_lock swig_mutex_own;
++    static Mutex swig_mutex_own;
+ #endif
+ 
+   public:
+@@ -382,7 +464,7 @@ namespace Swig {
+   };
+ 
+ #ifdef __THREAD__
+-  PyThread_type_lock Director::swig_mutex_own = PyThread_allocate_lock();
++  Mutex Director::swig_mutex_own;
+ #endif
+ }
+ 
+diff --git a/Lib/python/pybuffer.i b/Lib/python/pybuffer.i
+index 2fdaa6d6e..9ebc36a8c 100644
+--- a/Lib/python/pybuffer.i
++++ b/Lib/python/pybuffer.i
+@@ -12,18 +12,43 @@
+  *      }
+  */
+ 
++/* Note that in Py_LIMITED_API case we have no choice, but to use deprecated
++ * functions, as they provides the only way to access buffer data with limited
++ * API, which doesn't include Py_buffer definition. We also disable the
++ * warnings about doing this because they're not useful in our case.
++ */
++
+ %define %pybuffer_mutable_binary(TYPEMAP, SIZE)
+ %typemap(in) (TYPEMAP, SIZE) {
+   int res; Py_ssize_t size = 0; void *buf = 0;
++%#ifndef Py_LIMITED_API
+   Py_buffer view;
+   res = PyObject_GetBuffer($input, &view, PyBUF_WRITABLE);
++%#else
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic push
++    %#pragma GCC diagnostic ignored "-Wdeprecated"
++    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++  %#elif defined(_MSC_VER)
++    %#pragma warning(push)
++    %#pragma warning(disable: 4996)
++  %#endif
++  res = PyObject_AsWriteBuffer($input, &buf, &size);
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic pop
++  %#elif defined(_MSC_VER)
++    %#pragma warning(pop)
++  %#endif
++%#endif
+   if (res < 0) {
+     PyErr_Clear();
+     %argument_fail(res, "(TYPEMAP, SIZE)", $symname, $argnum);
+   }
++%#ifndef Py_LIMITED_API
+   size = view.len;
+   buf = view.buf;
+   PyBuffer_Release(&view);
++%#endif
+   $1 = ($1_ltype) buf;
+   $2 = ($2_ltype) (size/sizeof($*1_type));
+ }
+@@ -45,14 +70,34 @@
+ %define %pybuffer_mutable_string(TYPEMAP)
+ %typemap(in) (TYPEMAP) {
+   int res; void *buf = 0;
++%#ifndef Py_LIMITED_API
+   Py_buffer view;
+   res = PyObject_GetBuffer($input, &view, PyBUF_WRITABLE);
++%#else
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic push
++    %#pragma GCC diagnostic ignored "-Wdeprecated"
++    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++  %#elif defined(_MSC_VER)
++    %#pragma warning(push)
++    %#pragma warning(disable: 4996)
++  %#endif
++  Py_ssize_t size;
++  res = PyObject_AsWriteBuffer($input, &buf, &size);
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic pop
++  %#elif defined(_MSC_VER)
++    %#pragma warning(pop)
++  %#endif
++%#endif
+   if (res < 0) {
+     PyErr_Clear();
+     %argument_fail(res, "(TYPEMAP)", $symname, $argnum);
+   }
++%#ifndef Py_LIMITED_API
+   buf = view.buf;
+   PyBuffer_Release(&view);
++%#endif
+   $1 = ($1_ltype) buf;
+ }
+ %enddef
+@@ -74,15 +119,34 @@
+ %define %pybuffer_binary(TYPEMAP, SIZE)
+ %typemap(in) (TYPEMAP, SIZE) {
+   int res; Py_ssize_t size = 0; const void *buf = 0;
++%#ifndef Py_LIMITED_API
+   Py_buffer view;
+   res = PyObject_GetBuffer($input, &view, PyBUF_CONTIG_RO);
++%#else
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic push
++    %#pragma GCC diagnostic ignored "-Wdeprecated"
++    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++  %#elif defined(_MSC_VER)
++    %#pragma warning(push)
++    %#pragma warning(disable: 4996)
++  %#endif
++  res = PyObject_AsReadBuffer($input, &buf, &size);
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic pop
++  %#elif defined(_MSC_VER)
++    %#pragma warning(pop)
++  %#endif
++%#endif
+   if (res < 0) {
+     PyErr_Clear();
+     %argument_fail(res, "(TYPEMAP, SIZE)", $symname, $argnum);
+   }
++%#ifndef Py_LIMITED_API
+   size = view.len;
+   buf = view.buf;
+   PyBuffer_Release(&view);
++%#endif
+   $1 = ($1_ltype) buf;
+   $2 = ($2_ltype) (size / sizeof($*1_type));
+ }
+@@ -106,14 +170,34 @@
+ %define %pybuffer_string(TYPEMAP)
+ %typemap(in) (TYPEMAP) {
+   int res; const void *buf = 0;
++%#ifndef Py_LIMITED_API
+   Py_buffer view;
+   res = PyObject_GetBuffer($input, &view, PyBUF_CONTIG_RO);
++%#else
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic push
++    %#pragma GCC diagnostic ignored "-Wdeprecated"
++    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++  %#elif defined(_MSC_VER)
++    %#pragma warning(push)
++    %#pragma warning(disable: 4996)
++  %#endif
++  Py_ssize_t size;
++  res = PyObject_AsReadBuffer($input, &buf, &size);
++  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
++    %#pragma GCC diagnostic pop
++  %#elif defined(_MSC_VER)
++    %#pragma warning(pop)
++  %#endif
++%#endif
+   if (res < 0) {
+     PyErr_Clear();
+     %argument_fail(res, "(TYPEMAP)", $symname, $argnum);
+   }
++%#ifndef Py_LIMITED_API
+   buf = view.buf;
+   PyBuffer_Release(&view);
++%#endif
+   $1 = ($1_ltype) buf;
+ }
+ %enddef
+diff --git a/Lib/python/pyhead.swg b/Lib/python/pyhead.swg
+index d3730a8fa..4ec5c2c07 100644
+--- a/Lib/python/pyhead.swg
++++ b/Lib/python/pyhead.swg
+@@ -36,7 +36,7 @@
+ SWIGINTERN char*
+ SWIG_Python_str_AsChar(PyObject *str)
+ {
+-#if PY_VERSION_HEX >= 0x03030000
++#if PY_VERSION_HEX >= 0x03030000 && !defined(Py_LIMITED_API)
+   return (char *)PyUnicode_AsUTF8(str);
+ #elif PY_VERSION_HEX >= 0x03000000
+   char *newstr = 0;
+@@ -57,7 +57,7 @@ SWIG_Python_str_AsChar(PyObject *str)
+ #endif
+ }
+ 
+-#if PY_VERSION_HEX >= 0x03030000 || PY_VERSION_HEX < 0x03000000
++#if (PY_VERSION_HEX >= 0x03030000 && !defined(Py_LIMITED_API)) || PY_VERSION_HEX < 0x03000000
+ #  define SWIG_Python_str_DelForPy3(x)
+ #else
+ #  define SWIG_Python_str_DelForPy3(x) free( (void*) (x) )
+@@ -92,3 +92,17 @@ SWIG_Python_str_FromChar(const char *c)
+ #define PyDescr_NAME(x) (((PyDescrObject *)(x))->d_name)
+ #define Py_hash_t long
+ #endif
++
++#ifdef Py_LIMITED_API
++# define PyTuple_GET_ITEM PyTuple_GetItem
++/* Note that PyTuple_SetItem() has different semantics from PyTuple_SET_ITEM as it decref's the original tuple item, so in general they cannot be used
++  interchangeably. However in SWIG-generated code PyTuple_SET_ITEM is only used with newly initialized tuples without any items and for them this does work. */
++# define PyTuple_SET_ITEM PyTuple_SetItem
++# define PyTuple_GET_SIZE PyTuple_Size
++# define PyCFunction_GET_FLAGS PyCFunction_GetFlags
++# define PyCFunction_GET_FUNCTION PyCFunction_GetFunction
++# define PyCFunction_GET_SELF PyCFunction_GetSelf
++# define PyList_GET_ITEM PyList_GetItem
++# define PyList_SET_ITEM PyList_SetItem
++# define PySliceObject PyObject
++#endif
+diff --git a/Lib/python/pyrun.swg b/Lib/python/pyrun.swg
+index 935885934..bc3e2417b 100644
+--- a/Lib/python/pyrun.swg
++++ b/Lib/python/pyrun.swg
+@@ -334,6 +334,7 @@ swig_varlink_setattr(swig_varlinkobject *v, char *n, PyObject *p) {
+ SWIGINTERN PyTypeObject*
+ swig_varlink_type(void) {
+   static char varlink__doc__[] = "Swig var link object";
++#ifndef Py_LIMITED_API
+   static PyTypeObject varlink_type;
+   static int type_init = 0;
+   if (!type_init) {
+@@ -398,12 +399,28 @@ swig_varlink_type(void) {
+       return NULL;
+   }
+   return &varlink_type;
++#else // Py_LIMITED_API
++  PyType_Slot slots[] = {
++    { Py_tp_dealloc, (void*)swig_varlink_dealloc },
++    { Py_tp_repr, (void*)swig_varlink_repr },
++    { Py_tp_getattr, (void*)swig_varlink_getattr },
++    { Py_tp_setattr, (void*)swig_varlink_setattr },
++    { Py_tp_str, (void*)swig_varlink_str },
++    { Py_tp_doc, (void*)varlink__doc__ },
++    { 0, NULL }
++  };
++  PyType_Spec spec = {0};
++  spec.name = "swigvarlink";
++  spec.basicsize = sizeof(swig_varlinkobject);
++  spec.slots = slots;
++  return (PyTypeObject*)PyType_FromSpec(&spec);
++#endif // Py_LIMITED_API
+ }
+ 
+ /* Create a variable linking object for use later */
+ SWIGINTERN PyObject *
+ SWIG_Python_newvarlink(void) {
+-  swig_varlinkobject *result = PyObject_NEW(swig_varlinkobject, swig_varlink_type());
++  swig_varlinkobject *result = PyObject_New(swig_varlinkobject, swig_varlink_type());
+   if (result) {
+     result->vars = 0;
+   }
+@@ -714,6 +731,14 @@ SwigPyObject_Check(PyObject *op) {
+   if (PyType_IsSubtype(op->ob_type, target_tp))
+     return 1;
+   return (strcmp(op->ob_type->tp_name, "SwigPyObject") == 0);
++#elif defined(Py_LIMITED_API)
++  int cmp;
++  PyObject *tp_name = PyObject_GetAttrString((PyObject*)Py_TYPE(op), "__name__");
++  if (!tp_name)
++    return 0;
++  cmp = PyUnicode_CompareWithASCIIString(tp_name, "SwigPyObject");
++  Py_DECREF(tp_name);
++  return cmp == 0;
+ #else
+   return (Py_TYPE(op) == SwigPyObject_type())
+     || (strcmp(Py_TYPE(op)->tp_name,"SwigPyObject") == 0);
+@@ -859,7 +884,7 @@ swigobject_methods[] = {
+ SWIGRUNTIME PyTypeObject*
+ SwigPyObject_TypeOnce(void) {
+   static char swigobject_doc[] = "Swig object carries a C/C++ instance pointer";
+-
++#ifndef Py_LIMITED_API
+   static PyNumberMethods SwigPyObject_as_number = {
+     (binaryfunc)0, /*nb_add*/
+     (binaryfunc)0, /*nb_subtract*/
+@@ -991,12 +1016,30 @@ SwigPyObject_TypeOnce(void) {
+       return NULL;
+   }
+   return &swigpyobject_type;
++#else // Py_LIMITED_API
++  PyType_Slot slots[] = {
++    { Py_tp_dealloc, (void*)SwigPyObject_dealloc },
++    { Py_tp_repr, (void*)SwigPyObject_repr },
++    { Py_tp_getattro, (void*)PyObject_GenericGetAttr },
++    { Py_tp_doc, (void*)swigobject_doc },
++    { Py_tp_richcompare, (void*)SwigPyObject_richcompare },
++    { Py_tp_methods, (void*)swigobject_methods },
++    { Py_nb_int, (void*)SwigPyObject_long },
++    { 0, NULL }
++  };
++  PyType_Spec spec = {0};
++  spec.name = "SwigPyObject";
++  spec.basicsize = sizeof(SwigPyObject);
++  spec.flags = Py_TPFLAGS_DEFAULT;
++  spec.slots = slots;
++  return (PyTypeObject*)PyType_FromSpec(&spec);
++#endif // Py_LIMITED_API
+ }
+ 
+ SWIGRUNTIME PyObject *
+ SwigPyObject_New(void *ptr, swig_type_info *ty, int own)
+ {
+-  SwigPyObject *sobj = PyObject_NEW(SwigPyObject, SwigPyObject_type());
++  SwigPyObject *sobj = PyObject_New(SwigPyObject, SwigPyObject_type());
+   if (sobj) {
+     sobj->ptr  = ptr;
+     sobj->ty   = ty;
+@@ -1067,8 +1110,18 @@ SwigPyPacked_type(void) {
+ 
+ SWIGRUNTIMEINLINE int
+ SwigPyPacked_Check(PyObject *op) {
++#ifndef Py_LIMITED_API
+   return ((op)->ob_type == SwigPyPacked_TypeOnce()) 
+     || (strcmp((op)->ob_type->tp_name,"SwigPyPacked") == 0);
++#else
++  int cmp;
++  PyObject *tp_name = PyObject_GetAttrString((PyObject*)Py_TYPE(op), "__name__");
++  if (!tp_name)
++    return 0;
++  cmp = PyUnicode_CompareWithASCIIString(tp_name, "SwigPyPacked");
++  Py_DECREF(tp_name);
++  return cmp == 0;
++#endif
+ }
+ 
+ SWIGRUNTIME void
+@@ -1084,6 +1137,7 @@ SwigPyPacked_dealloc(PyObject *v)
+ SWIGRUNTIME PyTypeObject*
+ SwigPyPacked_TypeOnce(void) {
+   static char swigpacked_doc[] = "Swig object carries a C/C++ instance pointer";
++#ifndef Py_LIMITED_API
+   static PyTypeObject swigpypacked_type;
+   static int type_init = 0;
+   if (!type_init) {
+@@ -1171,12 +1225,28 @@ SwigPyPacked_TypeOnce(void) {
+       return NULL;
+   }
+   return &swigpypacked_type;
++#else
++  PyType_Slot slots[] = {
++    { Py_tp_dealloc, (void*)SwigPyPacked_dealloc },
++    { Py_tp_repr, (void*)SwigPyPacked_repr },
++    { Py_tp_str, (void*)SwigPyPacked_str },
++    { Py_tp_getattro, (void*)PyObject_GenericGetAttr },
++    { Py_tp_doc, swigpacked_doc },
++    { 0, NULL }
++  };
++  PyType_Spec spec = {0};
++  spec.name = "SwigPyPacked";
++  spec.basicsize = sizeof(SwigPyPacked);
++  spec.flags = Py_TPFLAGS_DEFAULT;
++  spec.slots = slots;
++  return (PyTypeObject*)PyType_FromSpec(&spec);
++#endif
+ }
+ 
+ SWIGRUNTIME PyObject *
+ SwigPyPacked_New(void *ptr, size_t size, swig_type_info *ty)
+ {
+-  SwigPyPacked *sobj = PyObject_NEW(SwigPyPacked, SwigPyPacked_type());
++  SwigPyPacked *sobj = PyObject_New(SwigPyPacked, SwigPyPacked_type());
+   if (sobj) {
+     void *pack = malloc(size);
+     if (pack) {
+@@ -1421,10 +1491,18 @@ SWIG_Python_ConvertFunctionPtr(PyObject *obj, void **ptr, swig_type_info *ty) {
+     swig_cast_info *tc;
+ 
+     /* here we get the method pointer for callbacks */
++#ifndef Py_LIMITED_API
+     const char *doc = (((PyCFunctionObject *)obj) -> m_ml -> ml_doc);
++#else
++    PyObject* pystr_doc = PyObject_GetAttrString(obj, "__doc__");
++    const char *doc = pystr_doc ? SWIG_Python_str_AsChar(pystr_doc) : 0;
++#endif
+     const char *desc = doc ? strstr(doc, "swig_ptr: ") : 0;
+     if (desc)
+       desc = ty ? SWIG_UnpackVoidPtr(desc + 10, &vptr, ty->name) : 0;
++#ifdef Py_LIMITED_API
++    SWIG_Python_str_DelForPy3(doc);
++#endif
+     if (!desc)
+       return SWIG_ERROR;
+     tc = SWIG_TypeCheck(desc,ty);
+@@ -1500,14 +1578,23 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
+     if (empty_args) {
+       PyObject *empty_kwargs = PyDict_New();
+       if (empty_kwargs) {
+-        inst = ((PyTypeObject *)data->newargs)->tp_new((PyTypeObject *)data->newargs, empty_args, empty_kwargs);
++#ifndef Py_LIMITED_API
++        newfunc newfn = ((PyTypeObject *)data->newargs)->tp_new;
++#else
++        newfunc newfn = (newfunc)PyType_GetSlot((PyTypeObject *)data->newargs, Py_tp_new);
++#endif
++        inst = newfn((PyTypeObject *)data->newargs, empty_args, empty_kwargs);
+         Py_DECREF(empty_kwargs);
+         if (inst) {
+           if (PyObject_SetAttr(inst, SWIG_This(), swig_this) == -1) {
+             Py_DECREF(inst);
+             inst = 0;
+           } else {
++#ifndef Py_LIMITED_API
+             Py_TYPE(inst)->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
++#else
++            PyType_Modified(Py_TYPE(inst));
++#endif
+           }
+         }
+       }
+@@ -1582,7 +1669,12 @@ SWIG_Python_NewPointerObj(PyObject *self, void *ptr, swig_type_info *type, int f
+     if (flags & SWIG_BUILTIN_TP_INIT) {
+       newobj = (SwigPyObject*) self;
+       if (newobj->ptr) {
+-        PyObject *next_self = clientdata->pytype->tp_alloc(clientdata->pytype, 0);
++#ifndef Py_LIMITED_API
++        allocfunc alloc = clientdata->pytype->tp_alloc;
++#else
++        allocfunc alloc = (allocfunc)PyType_GetSlot(clientdata->pytype, Py_tp_alloc);
++#endif
++        PyObject *next_self = alloc(clientdata->pytype, 0);
+         while (newobj->next)
+ 	  newobj = (SwigPyObject *) newobj->next;
+         newobj->next = next_self;
+@@ -1803,6 +1895,7 @@ SWIG_Python_TypeError(const char *type, PyObject *obj)
+     } else 
+ #endif      
+     {
++#ifndef Py_LIMITED_API // tp_name is not accessible
+       const char *otype = (obj ? obj->ob_type->tp_name : 0); 
+       if (otype) {
+ 	PyObject *str = PyObject_Str(obj);
+@@ -1818,6 +1911,7 @@ SWIG_Python_TypeError(const char *type, PyObject *obj)
+ 	Py_XDECREF(str);
+ 	return;
+       }
++#endif
+     }   
+     PyErr_Format(PyExc_TypeError, "a '%s' is expected", type);
+   } else {
+diff --git a/Source/Modules/python.cxx b/Source/Modules/python.cxx
+index 9aac91601..192abe104 100644
+--- a/Source/Modules/python.cxx
++++ b/Source/Modules/python.cxx
+@@ -68,6 +68,8 @@ static int no_header_file = 0;
+ static int max_bases = 0;
+ static int builtin_bases_needed = 0;
+ 
++static int py3_stable_abi = 0;
++
+ /* C++ Support + Shadow Classes */
+ 
+ static int have_constructor = 0;
+@@ -128,6 +130,7 @@ static const char *usage3 = "\
+      -nortti         - Disable the use of the native C++ RTTI with directors\n\
+      -nothreads      - Disable thread support for the entire interface\n\
+      -olddefs        - Keep the old method definitions when using -fastproxy\n\
++     -py3-stable-abi - Generate code compatible with Python 3 stable ABI (PEP 384)\n\
+      -relativeimport - Use relative Python imports\n\
+      -threads        - Add thread support for all the interface\n\
+      -O              - Enable the following optimization options:\n\
+@@ -392,6 +395,9 @@ public:
+ 	  fputs(usage1, stdout);
+ 	  fputs(usage2, stdout);
+ 	  fputs(usage3, stdout);
++	} else if (strcmp(argv[i], "-py3-stable-abi") == 0) {
++	  py3_stable_abi = 1;
++	  Swig_mark_arg(i);
+ 	} else if (strcmp(argv[i], "-builtin") == 0) {
+ 	  builtin = 1;
+ 	  Preprocessor_define("SWIGPYTHON_BUILTIN", 0);
+@@ -458,6 +464,16 @@ public:
+     if (doxygen)
+       doxygenTranslator = new PyDocConverter(doxygen_translator_flags);
+ 
++    if (py3_stable_abi && builtin) {
++      Printf(stderr, "-py3-stable-abi and -builtin options are not compatible.\n");
++      Exit(EXIT_FAILURE);
++    }
++
++    if (py3_stable_abi && fastproxy) {
++      Printf(stderr, "-py3-stable-abi and -fastproxy options are not compatible.  Disabling -fastproxy.\n");
++      fastproxy = 0;
++    }
++
+     if (!global_name)
+       global_name = NewString("cvar");
+     Preprocessor_define("SWIGPYTHON 1", 0);
+@@ -626,6 +642,10 @@ public:
+       Printf(f_runtime, "#define SWIGPYTHON_FASTPROXY\n");
+     }
+ 
++    if (py3_stable_abi) {
++      Printf(f_runtime, "#define Py_LIMITED_API 0x03040000\n");
++    }
++
+     Printf(f_runtime, "\n");
+ 
+     Printf(f_header, "#ifdef SWIG_TypeQuery\n");

--- a/deps.windows/patches/swig/0002-remove-PCRE-cmake-finder.patch
+++ b/deps.windows/patches/swig/0002-remove-PCRE-cmake-finder.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8a8862f63..d440ed72d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -75,9 +75,10 @@ endif ()
+ 
+ option (WITH_PCRE "Enable PCRE" ON)
+ if (WITH_PCRE)
+-  find_package (PCRE2 REQUIRED)
++  set(PCRE2_USE_STATIC_LIBS ON)
++  find_package(PCRE2 CONFIG COMPONENTS 8BIT)
+   set (HAVE_PCRE 1)
+-  include_directories (${PCRE2_INCLUDE_DIRS})
++  include_directories (${PCRE2_INCLUDE_DIR})
+ endif()
+ 
+ if (WIN32)
+@@ -146,7 +147,7 @@ add_executable (swig
+   ${PROJECT_BINARY_DIR}/Source/CParse/parser.h
+ )
+ if (PCRE2_FOUND)
+-  target_link_libraries (swig ${PCRE2_LIBRARIES})
++  target_link_libraries (swig PCRE2::8BIT)
+ endif ()
+ install (TARGETS swig DESTINATION bin)
+ 
+diff --git a/Tools/cmake/FindPCRE2.cmake b/Tools/cmake/FindPCRE2.cmake
+deleted file mode 100644
+index 08c216347..000000000
+--- a/Tools/cmake/FindPCRE2.cmake
++++ /dev/null
+@@ -1,21 +0,0 @@
+-# - Find PCRE2
+-# Perl Compatible Regular Expressions
+-# https://www.pcre.org/
+-
+-# The following variables are set:
+-# PCRE2_FOUND - System has the PCRE library
+-# PCRE2_LIBRARIES - The PCRE library file
+-# PCRE2_INCLUDE_DIRS - The folder with the PCRE headers
+-
+-find_library(PCRE2_LIBRARY NAMES pcre2 pcre2-8)
+-find_path(PCRE2_INCLUDE_DIR pcre2.h)
+-
+-set (PCRE2_LIBRARIES ${PCRE2_LIBRARY})
+-set (PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
+-
+-include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(PCRE2 DEFAULT_MSG PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS)
+-
+-mark_as_advanced (
+-  PCRE2_LIBRARY
+-  PCRE2_INCLUDE_DIR)

--- a/utils.pwsh/Invoke-GitCheckout.ps1
+++ b/utils.pwsh/Invoke-GitCheckout.ps1
@@ -74,7 +74,7 @@ function Invoke-GitCheckout {
 
         if ( $PullRequest -ne "" ) {
             try {
-                Invoke-External git show-ref --quiet --verify refs/heads/pr-$PullRequest
+                Invoke-External git show-ref --quiet --verify refs/heads/pull-$PullRequest
             } catch {
                 Invoke-External git fetch origin $("pull/{0}/head:pull-{0}" -f $PullRequest)
             } finally {


### PR DESCRIPTION
### Description
Adds swig to precompiled binaries for Windows with applied patch for Py3 stable ABI patch.

### Motivation and Context
Support for the Python 3 stable ABI allows Python scripting support in OBS to use a wider range of available Python 3 versions vs. being pinned to the version the scripting module is compiled with.

### How Has This Been Tested?
* Built and packaged Swig locally
* Compiled obspython with Swig compiled with these changes

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
