### PR TITLE
utils.pwsh: Skip git checkout if SkipUnpack is passed

### DIFF
--- a/utils.pwsh/Setup-Dependency.ps1
+++ b/utils.pwsh/Setup-Dependency.ps1
@@ -38,7 +38,9 @@ function Setup-Dependency {
             $Params += @{PullRequest = $PullRequest}
         }
 
-        Invoke-GitCheckout  @Params
+        if ( ! ( $script:SkipUnpack ) ) {
+            Invoke-GitCheckout  @Params
+        }
     } else {
         $File = [System.IO.Path]::GetFileName($Uri)
 


### PR DESCRIPTION
### Description
Fix obs-deps releases created from cache missing patched Swig library files.

### Motivation and Context
When build directories are restored from cache on CI, it is expected that patched files stay patched. Without this fix, a git checkout takes place, which resets files to their unpatched state.

### How Has This Been Tested?
* Needs to be tested on CI (uncached + cached runs).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
