### PR TITLE
CI: Add functionality to install winget on CI host systems

### DIFF
--- a/.Wingetfile
+++ b/.Wingetfile
@@ -1,2 +1,3 @@
 package '7zip.7zip', path: '7-zip', bin: '7z'
 package 'cmake', path: 'Cmake\bin', bin: 'cmake'
+package 'mesonbuild.meson', path: 'Meson', bin: 'meson'

--- a/utils.pwsh/Check-Winget.ps1
+++ b/utils.pwsh/Check-Winget.ps1
@@ -1,0 +1,69 @@
+function Check-Winget {
+    <#
+        .SYNOPSIS
+            Ensures available winget installation on host system.
+        .DESCRIPTION
+            Checks whether winget is available on the system and install from Github releases.
+        .EXAMPLE
+            Check-Winget
+    #>
+
+    if ( ! ( Test-Path function:Log-Information ) ) {
+        . $PSScriptRoot/Logger.ps1
+    }
+
+    if ( ! ( Test-Path function:Test-CommandExists ) ) {
+        . $PSScriptRoot/Test-CommandExists.ps1
+    }
+
+    Log-Information 'Check for Winget'
+
+    if ( ! ( Test-CommandExists winget ) ) {
+        if ( ! ( Test-Path function:Invoke-SafeWebRequest ) ) {
+            . $PSScriptRoot/Invoke-SafeWebRequest.ps1
+        }
+
+        Log-Warning 'Winget not found, attempting to install...'
+
+        if ( ! ( Test-Path function:Ensure-Location ) ) {
+            . $PSScriptRoot/Ensure-Location.ps1
+        }
+
+        Push-Location -Stack BuildTemp
+
+        Ensure-Location -Path "${PSScriptRoot}/temp"
+
+        $_RequiredPackages = @(
+            'https://github.com/microsoft/winget-cli/releases/download/v1.2.10271/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle'
+            'https://github.com/microsoft/winget-cli/releases/download/v1.2.10271/b0a0692da1034339b76dce1c298a1e42_License1.xml'
+        )
+
+        if ( $script:Target -eq 'x64' ) {
+            $_RequiredPackages += @('https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx')
+        } else {
+            $_RequiredPackages += @('https://aka.ms/Microsoft.VCLibs.x86.14.00.Desktop.appx')
+        }
+
+        $_RequiredPackages | Foreach-Object {
+            $_Url = $_
+            $_BaseName = [System.IO.Path]::GetFileName($_Url)
+            $_HashFile = "${PSScriptRoot}/checksums/${_BaseName}.sha256"
+
+            Invoke-SafeWebRequest -Uri $_Url -HashFile $_HashFile
+        }
+
+        $_Params = @{
+            Online = $true
+            PackagePath = './Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle'
+            LicensePath = './b0a0692da1034339b76dce1c298a1e42_License1.xml'
+            DependencyPackagePath = "$(if ( $script:Target -eq 'x64' ) { './Microsoft.VCLibs.x64.14.00.Desktop.appx' } else { './Microsoft.VCLibs.x86.14.00.Desktop.appx' })"
+        }
+
+        Add-AppxProvisionedPackage @_Params
+
+        Pop-Location -Stack BuildTemp
+    } else {
+        Log-Debug "Winget found at $(Get-Command winget)"
+        Log-Status 'Winget found'
+    }
+}

--- a/utils.pwsh/Ensure-Location.ps1
+++ b/utils.pwsh/Ensure-Location.ps1
@@ -12,18 +12,18 @@ function Ensure-Location {
 
     param(
         [Parameter(Mandatory)]
-        [string] $Directory
+        [string] $Path
     )
 
-    if ( ! ( Test-Path $Directory ) ) {
+    if ( ! ( Test-Path $Path ) ) {
         $_Params = @{
             ItemType = "Directory"
-            Path = $Directory
+            Path = $Path
             ErrorAction = "SilentlyContinue"
         }
 
         New-Item @_Params | Set-Location
     } else {
-        Set-Location -Path $Directory
+        Set-Location -Path $Path
     }
 }

--- a/utils.pwsh/Setup-Host.ps1
+++ b/utils.pwsh/Setup-Host.ps1
@@ -3,6 +3,12 @@ function Setup-Host {
         . $PSScriptRoot/Logger.ps1
     }
 
+    if ( ! ( Test-Path function:Check-Winget ) ) {
+        . $PSScriptRoot/Check-Winget.ps1
+    }
+
+    Check-Winget
+
     if ( ! ( Test-Path function:Check-Git ) ) {
         . $PSScriptRoot/Check-Git.ps1
     }

--- a/utils.pwsh/checksums/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle.sha256
+++ b/utils.pwsh/checksums/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">B8BD1F72246E877BD9C4620D8AC1F7A498F25A30C7E59AB9BED34ED24E49E660</S>
+      <S N="Path">C:\Users\patthemav\source\repos\obs-deps\utils.pwsh\temp\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/utils.pwsh/checksums/Microsoft.VCLibs.x64.14.00.Desktop.appx.sha256
+++ b/utils.pwsh/checksums/Microsoft.VCLibs.x64.14.00.Desktop.appx.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">9BFDE6CFCC530EF073AB4BC9C4817575F63BE1251DD75AAA58CB89299697A569</S>
+      <S N="Path">C:\Users\patthemav\source\repos\obs-deps\utils.pwsh\temp\Microsoft.VCLibs.x64.14.00.Desktop.appx</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/utils.pwsh/checksums/Microsoft.VCLibs.x86.14.00.Desktop.appx.sha256
+++ b/utils.pwsh/checksums/Microsoft.VCLibs.x86.14.00.Desktop.appx.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">3195DB914BEA1534EE73582CD483C548A929AED2799D305B3BBF7411BA7A6C7D</S>
+      <S N="Path">C:\Users\patthemav\source\repos\obs-deps\utils.pwsh\temp\Microsoft.VCLibs.x86.14.00.Desktop.appx</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/utils.pwsh/checksums/b0a0692da1034339b76dce1c298a1e42_License1.xml.sha256
+++ b/utils.pwsh/checksums/b0a0692da1034339b76dce1c298a1e42_License1.xml.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">41EABA6E261D8D9473CA0490296E37D8F848A43D105210CDDB022BFB57C58172</S>
+      <S N="Path">C:\Users\patthemav\source\repos\obs-deps\utils.pwsh\temp\b0a0692da1034339b76dce1c298a1e42_License1.xml</S>
+    </Props>
+  </Obj>
+</Objs>


### PR DESCRIPTION
### Description
Add additional functions to check for and (if necessary) install widget, which the Powershell framework relies on to install additional build tools.

### Motivation and Context
While modern Windows 10 and all Windows 11 installations usually come with winget pre-installed, CI runners do not. This should ensure an available winget installation on GitHub Actions runners.

### How Has This Been Tested?
Tested locally, final tests need to happen on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
