### PR TITLE
Use Visual Studio 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -451,7 +451,7 @@ jobs:
 
   windows-build:
     name: 'Build Windows Dependencies'
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: true
       matrix:
@@ -531,7 +531,7 @@ jobs:
 
   windows-qt-build:
     name: 'Build Windows Qt'
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: true
       matrix:
@@ -589,7 +589,7 @@ jobs:
 
   windows-qt-package:
     name: 'Package Windows Qt (${{ matrix.qtVersion }}, ${{ matrix.target }})'
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: true
       matrix:

--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -79,13 +79,13 @@ function Find-VisualStudio {
     $VisualStudioData = Get-CimInstance MSFT_VSInstance
 
     # Prefer VS versions in this order:
-    # 1. VS2019 Release (stable)
-    # 2. VS2022 Release
-    # 3. VS2022 Preview
+    # 1. VS2022 Release (stable)
+    # 2. VS2022 Preview
+    # 3. VS2019 Release
     [string[]]$SupportedVSVersions =
-        "VisualStudio.16.Release",
         "VisualStudio.17.Release",
-        "VisualStudio.17.Preview"
+        "VisualStudio.17.Preview",
+        "VisualStudio.16.Release"
     $NumSupportedVSVersions = $SupportedVSVersions.length
 
     if ( $VisualStudioData.GetType() -eq [object[]] ) {

--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -78,8 +78,24 @@ function Find-VisualStudio {
 
     $VisualStudioData = Get-CimInstance MSFT_VSInstance
 
+    # Prefer VS versions in this order:
+    # 1. VS2019 Release (stable)
+    # 2. VS2022 Release
+    # 3. VS2022 Preview
+    [string[]]$SupportedVSVersions =
+        "VisualStudio.16.Release",
+        "VisualStudio.17.Release",
+        "VisualStudio.17.Preview"
+    $NumSupportedVSVersions = $SupportedVSVersions.length
+
     if ( $VisualStudioData.GetType() -eq [object[]] ) {
-        $VisualStudioData = ($VisualStudioData | Where-Object {$_.Version -ge 16} | Sort-Object -Property Version)[0]
+        for ( $i = 0; $i -lt $NumSupportedVSVersions; $i++ ) {
+            $VisualStudioDataTemp = ($VisualStudioData | Where-Object {$_.ChannelId -eq $SupportedVSVersions[$i]} | Sort-Object -Property Version)[0]
+            if ( $VisualStudioDataTemp ) {
+                break;
+            }
+        }
+        $VisualStudioData = $VisualStudioDataTemp
     }
 
     if ( ! ( $VisualStudioData ) -or ( $VisualStudioData.Version -lt 16 ) ) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR contains two commits. They can be split into separate PRs if needed.

----
utils.pwsh: Implement preferred Visual Studio versions

Allow preferring specific versions of Visual Studio by checking the ChannelId property. This allows trivial switching of what version of Visual Studio to use, though we still have a hard floor of VS2019.

----
Use VS2022 by default

This commit makes the necessary changes to the GitHub Actions workflow and to utils.pwsh/Setup-Target.ps1 to use VS2022 by default, and then fallback to VS2019 if VS2022 is not available.

----

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to switch to VS2022.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
