### PR TITLE
deps.qt: Backport Windows native scale factor fix

### DIFF
--- a/.github/actions/build-windows-qt/action.yml
+++ b/.github/actions/build-windows-qt/action.yml
@@ -25,7 +25,7 @@ runs:
       run: |
         $QtDepHash = (Get-FileHash -Path "${{ github.workspace }}/deps.qt/qt${{ inputs.qtVersion }}.ps1" -Algorithm "SHA256").Hash
         if ( Test-Path "${{ github.workspace }}/deps.qt/patches/Qt${{ inputs.qtVersion }}" ) {
-          $QtPatchHash = (Get-FileHash "${{ github.workspace }}/deps.qt/patches/Qt${{ inputs.qtVersion }}/win/0001-QTBUG-74606.patch" -Algorithm "SHA256").Hash
+          $QtPatchHash = (Get-FileHash "${{ github.workspace }}/deps.qt/patches/Qt${{ inputs.qtVersion }}/win/*.patch" -Algorithm "SHA256").Hash
         } else {
           $QtPatchHash = "nopatches"
         }

--- a/deps.qt/patches/Qt6/win/0001-QTBUG-86344.patch
+++ b/deps.qt/patches/Qt6/win/0001-QTBUG-86344.patch
@@ -1,0 +1,17 @@
+Submodule qtbase contains modified content
+diff --git a/qtbase/src/widgets/styles/qwindowsstyle.cpp b/qtbase/src/widgets/styles/qwindowsstyle.cpp
+index 39fabd1218..a2b4cc0ccc 100644
+--- a/qtbase/src/widgets/styles/qwindowsstyle.cpp
++++ b/qtbase/src/widgets/styles/qwindowsstyle.cpp
+@@ -409,7 +409,10 @@ static QScreen *screenOf(const QWidget *w)
+ // and account for secondary screens with differing logical DPI.
+ qreal QWindowsStylePrivate::nativeMetricScaleFactor(const QWidget *widget)
+ {
+-    qreal result = qreal(1) / QWindowsStylePrivate::devicePixelRatio(widget);
++    const QPlatformScreen *screen = screenOf(widget)->handle();
++    const qreal scale = screen ? (screen->logicalDpi().first / screen->logicalBaseDpi().first)
++                               : QWindowsStylePrivate::appDevicePixelRatio();
++    qreal result = qreal(1) / scale;
+     if (QGuiApplicationPrivate::screen_list.size() > 1) {
+         const QScreen *primaryScreen = QGuiApplication::primaryScreen();
+         const QScreen *screen = screenOf(widget);

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -2,7 +2,13 @@ param(
     [string] $Name = 'qt6',
     [string] $Version = '6.3.1',
     [string] $Uri = 'https://github.com/qt/qt5.git',
-    [string] $Hash = 'c3d2dfa229f87374fc5919b5c44606445cf94bd8'
+    [string] $Hash = 'c3d2dfa229f87374fc5919b5c44606445cf94bd8',
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/Qt6/win/0001-QTBUG-86344.patch"
+            HashSum = "688E7787CEA28047DF819AA00E16A81CA3BB7E331E7620268CCD38D1D533B4ED"
+        }
+    )
 )
 
 # References:
@@ -57,6 +63,11 @@ function Patch {
         $Params = $_
         Safe-Patch @Params
     }
+
+    Set-Location qtbase
+    Check-GitUser
+    git add .
+    git commit -m "Backport fix for QTBUG-86344"
 }
 
 function Configure {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Backport a fix from qt/qtbase@e3201e7124 to help address setups with multiple displays with different scale factors.

This patch can be dropped once we reach Qt 6.4.0 or newer.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Requested by @jpark37.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested builds of Qt locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
