### PR TITLE
Revert "deps.windows: Update VulkanSDK to 1.3.216.0"

### DIFF
--- a/deps.windows/40-vulkan.ps1
+++ b/deps.windows/40-vulkan.ps1
@@ -1,8 +1,8 @@
 param(
     [string] $Name = 'vulkansdk',
-    [string] $Version = '1.3.216.0',
-    [string] $Uri = 'https://sdk.lunarg.com/sdk/download/1.3.216.0/windows/VulkanSDK-1.3.216.0-Installer.exe',
-    [string] $Hash = "${PSScriptRoot}/checksums/VulkanSDK-1.3.216.0-Installer.exe.sha256"
+    [string] $Version = '1.2.131.2',
+    [string] $Uri = 'https://cdn-fastly.obsproject.com/downloads/VulkanSDK-1.2.131.2-Installer-Components.7z',
+    [string] $Hash = "${PSScriptRoot}/checksums/VulkanSDK-1.2.131.2-Installer-Components.7z.sha256"
 )
 
 function Setup {

--- a/deps.windows/checksums/VulkanSDK-1.2.131.2-Installer-Components.7z.sha256
+++ b/deps.windows/checksums/VulkanSDK-1.2.131.2-Installer-Components.7z.sha256
@@ -7,8 +7,8 @@
     <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
     <Props>
       <S N="Algorithm">SHA256</S>
-      <S N="Hash">32C0BBA765BD42D6E321FBB14A0ABBB6D305DA06F53DB7D369A3CC295DE111F8</S>
-      <S N="Path">VulkanSDK-1.3.216.0-Installer.exe</S>
+      <S N="Hash">49D515F091D69C005A9E52E69829D28383FE157A764CAEBAA3DBC4B8D9BB383D</S>
+      <S N="Path">VulkanSDK-1.2.131.2-Installer-Components.7z</S>
     </Props>
   </Obj>
 </Objs>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This reverts commit e03731a967298ce9915555a50377ff3b877b54db.

Updating Vulkan is more trouble than it's worth right now. Let's revert for now and update this some other time.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to ship new deps. Don't want to mess around with trying to make sure game capture works with updated Vulkan files.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
We've previously used this.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
