### PR TITLE
deps.ffmpeg: Update SVT-AV1 repository url

### DIFF
--- a/deps.ffmpeg/30-svt-av1.zsh
+++ b/deps.ffmpeg/30-svt-av1.zsh
@@ -3,7 +3,7 @@ autoload -Uz log_debug log_error log_info log_status log_output
 ## Dependency Information
 local name='svt-av1'
 local version='1.1.0'
-local url='https://github.com/AOMediaCodec/SVT-AV1.git'
+local url='https://gitlab.com/AOMediaCodec/SVT-AV1.git'
 local hash='6e87a1de98281840abebc030781780edd822bae5'
 
 ## Dependency Overrides


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
According to https://gitlab.com/AOMediaCodec/SVT-AV1, the canonical URL for this project moved to  https://gitlab.com/AOMediaCodec/SVT-AV1. I change the repository url to new one

### Motivation and Context
github actions failed when I use the same code in my own repository

### How Has This Been Tested?
CI build success.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
