### PR TITLE
deps.qt: Fix macOS build by disabling VCPKG

### DIFF
--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -91,6 +91,7 @@ config() {
   if (( ${+commands[ccache]} )) common_cmake_flags+=(-DQT_USE_CCACHE=ON)
 
   if [[ ${CPUTYPE} != "${arch}" && ${host_os} == 'macos' ]] {
+    unset VCPKG_ROOT
     if ! /usr/bin/pgrep -q oahd; then
       local -A other_arch=(arm64 x86_64 x86_64 arm64)
       common_cmake_flags+=(-DCMAKE_OSX_ARCHITECTURES="${CPUTYPE};${other_arch[${CPUTYPE}]}")


### PR DESCRIPTION
The macOS Qt6 Universal build fails on GitHub actions due to a suspected bug in vcpkg. Disable using vcpkg until a proper fix is found.

This is an RFC pull request. I don't know if it is the best solution and I'm looking for feedback.

Fixes: #135

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Has had some minimal testing on an unattached repo (https://github.com/glikely/obs-deps-2. Will get a full test when the CI Action is approved for this pull request.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
