### PR TITLE
deps.qt: Add QtSerialPort

### DIFF
--- a/deps.qt/checksums/qtserialport-everywhere-opensource-src-5.15.5.tar.xz.sha256
+++ b/deps.qt/checksums/qtserialport-everywhere-opensource-src-5.15.5.tar.xz.sha256
@@ -1,0 +1,1 @@
+549d096a9fd20c5d48bd014201afb88b570bce2be752aeaac2b2c80cb96ce275  qtserialport-everywhere-opensource-src-5.15.5.tar.xz

--- a/deps.qt/checksums/qtserialport-everywhere-src-6.3.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtserialport-everywhere-src-6.3.1.tar.xz.sha256
@@ -1,0 +1,1 @@
+4eb6d80e65799dd2e0318df4dfba14173c1929e861718cda9bedca24253b616e  qtserialport-everywhere-src-6.3.1.tar.xz

--- a/deps.qt/qt5.ps1
+++ b/deps.qt/qt5.ps1
@@ -44,7 +44,7 @@ function Setup {
 
     Check-GitUser
     $Options = @(
-        '--module-subset', 'qtbase,qtimageformats,qtmultimedia,qtsvg,qtwinextras'
+        '--module-subset', 'qtbase,qtimageformats,qtmultimedia,qtsvg,qtwinextras,qtserialport'
         '--force'
     )
     Invoke-External perl init-repository @Options

--- a/deps.qt/qt5.zsh
+++ b/deps.qt/qt5.zsh
@@ -27,6 +27,7 @@ local -a qt_components=(
   qtimageformats
   qtmultimedia
   qtsvg
+  qtserialport
 )
 local dir='qt5'
 

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -36,7 +36,7 @@ function Setup {
     # This will fail if any of the repos are dirty (uncommitted patches).
     Set-Location qt6
     $Options = @(
-        '--module-subset', 'qtbase,qtimageformats,qtmultimedia,qtshadertools,qtsvg'
+        '--module-subset', 'qtbase,qtimageformats,qtmultimedia,qtshadertools,qtsvg,qtserialport'
         '--force'
     )
     Invoke-External perl init-repository @Options

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -13,6 +13,7 @@ local -a qt_components=(
   'qtshadertools'
   'qtmultimedia'
   'qtsvg'
+  'qtserialport'
 )
 
 local dir='qt6'


### PR DESCRIPTION
### Description
At least one plugin (obs-ptz) requires the QtSerialPort library. Add it to the base set of OBS Qt dependencies so that the plugin doesn't need to supply its own copy which simplifies the build and also ensures the library versions remain in-sync with each other.

### How Has This Been Tested?
Tested with the obs-ptz plugin. Builds successfully on Windows and macOS

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
