### PR TITLE
Update GitHub Actions for set-output deprecation

### DIFF
--- a/.github/actions/build-ffmpeg/action.yml
+++ b/.github/actions/build-ffmpeg/action.yml
@@ -37,7 +37,7 @@ runs:
         esac
 
         ffmpeg_dep_hash=$(cat ${{ github.workspace }}/deps.ffmpeg/*.zsh | sha256sum | cut -d " " -f 1)
-        echo "::set-output name=hash::${ffmpeg_dep_hash}"
+        echo "hash=${ffmpeg_dep_hash}" >> $GITHUB_OUTPUT
 
     - name: Restore FFmpeg Dependencies from Cache
       id: ffmpeg-deps-cache

--- a/.github/actions/build-macos-deps/action.yml
+++ b/.github/actions/build-macos-deps/action.yml
@@ -37,7 +37,7 @@ runs:
         esac
 
         deps_hash=$(cat ${{ github.workspace }}/deps.macos/*.zsh | sha256sum | cut -d " " -f 1)
-        echo "::set-output name=hash::${deps_hash}"
+        echo "hash=${deps_hash}" >> $GITHUB_OUTPUT
 
     - name: Restore macOS Dependencies from Cache
       id: deps-cache

--- a/.github/actions/build-macos-qt/action.yml
+++ b/.github/actions/build-macos-qt/action.yml
@@ -36,8 +36,8 @@ runs:
           qt_patch_hash=$(echo '' | sha256sum | cut -d " " -f 1)
         }
 
-        print "::set-output name=depHash::${qt_dep_hash}"
-        print "::set-output name=patchHash::${qt_patch_hash}"
+        print "depHash=${qt_dep_hash}" >> $GITHUB_OUTPUT
+        print "patchHash=${qt_patch_hash}" >> $GITHUB_OUTPUT
 
     - name: Restore macOS Qt from Cache
       id: deps-cache

--- a/.github/actions/build-windows-deps/action.yml
+++ b/.github/actions/build-windows-deps/action.yml
@@ -26,7 +26,7 @@ runs:
         Get-Content .\deps.windows\*.ps1 > temp.txt
         $DepsHash = ((Get-FileHash -Path temp.txt -Algorithm SHA256).Hash)
 
-        Write-Host "::set-output name=hash::${DepsHash}"
+        "hash=${DepsHash}" >> $env:GITHUB_OUTPUT
 
     - name: Restore Windows Dependencies from Cache
       id: deps-cache

--- a/.github/actions/build-windows-qt/action.yml
+++ b/.github/actions/build-windows-qt/action.yml
@@ -30,8 +30,8 @@ runs:
           $QtPatchHash = "nopatches"
         }
 
-        Write-Output "::set-output name=depHash::${QtDepHash}"
-        Write-Output "::set-output name=patchHash::${QtPatchHash}"
+        "depHash=${QtDepHash}" >> $env:GITHUB_OUTPUT
+        "patchHash=${QtPatchHash}" >> $env:GITHUB_OUTPUT
 
     - name: Restore Windows Qt from Cache
       id: deps-cache

--- a/.github/actions/create-single-arch/action.yml
+++ b/.github/actions/create-single-arch/action.yml
@@ -79,8 +79,8 @@ runs:
 
         mv ${file_name} ${{ github.workspace }}/${file_name}
 
-        print "::set-output name=artifactName::${artifact_name}"
-        print "::set-output name=artifactFileName::${file_name}"
+        print "artifactName=${artifact_name}" >> $GITHUB_OUTPUT
+        print "artifactFileName=${file_name}" >> $GITHUB_OUTPUT
 
     - name: Publish Build Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/actions/create-universal/action.yml
+++ b/.github/actions/create-universal/action.yml
@@ -82,8 +82,8 @@ runs:
 
         mv ${file_name} ${{ github.workspace }}/${file_name}
 
-        print "::set-output name=artifactName::${artifact_name}"
-        print "::set-output name=artifactFileName::${file_name}"
+        print "artifactName=${artifact_name}" >> $GITHUB_OUTPUT
+        print "artifactFileName=${file_name}" >> $GITHUB_OUTPUT
 
     - name: Publish Build Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/actions/package-windows-qt/action.yml
+++ b/.github/actions/package-windows-qt/action.yml
@@ -22,9 +22,9 @@ runs:
         $FileName = (Get-ChildItem -Filter "windows-deps-qt*.zip").Name.Replace("-RelWithDebInfo", "")
         $PDBArchiveFileName = (Get-ChildItem -Filter "windows-deps-qt*.zip").Name.Replace("RelWithDebInfo", "ReleasePDBs")
         $PDBOutputName = "${{ inputs.outputName }}".Replace("${{ inputs.base }}", "${{ inputs.base }}-ReleasePDBs")
-        Write-Output "::set-output name=fileName::${FileName}"
-        Write-Output "::set-output name=pdbFileName::${PDBArchiveFileName}"
-        Write-Output "::set-output name=pdbOutputName::${PDBOutputName}"
+        "fileName=${FileName}" >> $env:GITHUB_OUTPUT
+        "pdbFileName=${PDBArchiveFileName}" >> $env:GITHUB_OUTPUT
+        "pdbOutputName=${PDBOutputName}" >> $env:GITHUB_OUTPUT
 
     - name: Extract RelWithDebInfo
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,9 +83,9 @@ jobs:
           artifact_name="ffmpeg-${target}-${{ github.sha }}"
           file_name="${target%%-*}-ffmpeg-$(date +"%Y-%m-%d")-${target##*-}.tar.xz"
 
-          echo "::set-output name=artifactName::${artifact_name}"
-          echo "::set-output name=artifactFileName::${file_name}"
-          echo "::set-output name=ccacheDate::$(date +"%Y-%m-%d")"
+          echo "artifactName=${artifact_name}" >> $GITHUB_OUTPUT
+          echo "artifactFileName=${file_name}" >> $GITHUB_OUTPUT
+          echo "ccacheDate=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
 
       - name: Restore Compilation Cache
         id: ccache-cache
@@ -101,9 +101,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Build FFmpeg
@@ -134,9 +134,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create universal binary package
@@ -185,9 +185,9 @@ jobs:
           artifact_name="deps-${target}-${{ github.sha }}"
           file_name="${target%%-*}-deps-$(date +"%Y-%m-%d")-${target##*-}.tar.xz"
 
-          echo "::set-output name=artifactName::${artifact_name}"
-          echo "::set-output name=artifactFileName::${file_name}"
-          echo "::set-output name=ccacheDate::$(date +"%Y-%m-%d")"
+          echo "artifactName=${artifact_name}" >> $GITHUB_OUTPUT
+          echo "artifactFileName=${file_name}" >> $GITHUB_OUTPUT
+          echo "ccacheDate=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
 
       - name: Restore Compilation Cache
         id: ccache-cache
@@ -203,9 +203,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Build macOS Dependencies
@@ -236,9 +236,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create universal binary package
@@ -285,9 +285,9 @@ jobs:
           artifact_name="qt5-${target}-${{ github.sha }}"
           file_name="${target%%-*}-deps-qt5-$(date +"%Y-%m-%d")-${target##*-}.tar.xz"
 
-          echo "::set-output name=artifactName::${artifact_name}"
-          echo "::set-output name=artifactFileName::${file_name}"
-          echo "::set-output name=ccacheDate::$(date +"%Y-%m-%d")"
+          echo "artifactName=${artifact_name}" >> $GITHUB_OUTPUT
+          echo "artifactFileName=${file_name}" >> $GITHUB_OUTPUT
+          echo "ccacheDate=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
 
       - name: Restore Compilation Cache
         id: ccache-cache
@@ -303,9 +303,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Build macOS Qt5
@@ -336,9 +336,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create universal binary package
@@ -376,9 +376,9 @@ jobs:
           artifact_name="qt6-${target}-${{ github.sha }}"
           file_name="${target%%-*}-deps-qt6-$(date +"%Y-%m-%d")-${target##*-}.tar.xz"
 
-          echo "::set-output name=artifactName::${artifact_name}"
-          echo "::set-output name=artifactFileName::${file_name}"
-          echo "::set-output name=ccacheDate::$(date +"%Y-%m-%d")"
+          echo "artifactName=${artifact_name}" >> $GITHUB_OUTPUT
+          echo "artifactFileName=${file_name}" >> $GITHUB_OUTPUT
+          echo "ccacheDate=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
 
       - name: Restore Compilation Cache
         id: ccache-cache
@@ -394,9 +394,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Build macOS Qt6
@@ -436,9 +436,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [[ -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')" ]]; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create single architecture binary package
@@ -479,8 +479,8 @@ jobs:
           $ArtifactName="deps-windows-${Target}-${{ github.sha }}"
           $FileName="windows-deps-$(Get-Date -Format 'yyyy-MM-dd')-${Target}.zip"
 
-          Write-Output "::set-output name=artifactName::${ArtifactName}"
-          Write-Output "::set-output name=artifactFileName::${FileName}"
+          "artifactName=${ArtifactName}" >> $env:GITHUB_OUTPUT
+          "artifactFileName=${FileName}" >> $env:GITHUB_OUTPUT
 
       - name: 'Check for GitHub Labels'
         id: seekingTesters
@@ -499,7 +499,7 @@ jobs:
             $false
           }
 
-          Write-Output "::set-output name=found::$(([string]${LabelFound}).ToLower())"
+          "found=$(([string]${LabelFound}).ToLower())" >> $env:GITHUB_OUTPUT
 
       - name: Build ntv2 debug
         shell: pwsh
@@ -550,8 +550,8 @@ jobs:
           $ArtifactName="qt${{ matrix.qtVersion }}-windows-${{ matrix.target }}-${{ matrix.config }}-${{ github.sha }}"
           $FileName="windows-deps-qt${{ matrix.qtVersion }}-$(Get-Date -Format 'yyyy-MM-dd')-${{ matrix.target }}-${{ matrix.config }}.zip"
 
-          Write-Output "::set-output name=artifactName::${ArtifactName}"
-          Write-Output "::set-output name=artifactFileName::${FileName}"
+          "artifactName=${ArtifactName}" >> $env:GITHUB_OUTPUT
+          "artifactFileName=${FileName}" >> $env:GITHUB_OUTPUT
 
       - name: 'Check for GitHub Labels'
         id: seekingTesters
@@ -570,7 +570,7 @@ jobs:
             $false
           }
 
-          Write-Output "::set-output name=found::$(([string]${LabelFound}).ToLower())"
+          "found=$(([string]${LabelFound}).ToLower())" >> $env:GITHUB_OUTPUT
 
       - name: 'Build Windows Qt'
         uses: ./.github/actions/build-windows-qt
@@ -617,7 +617,7 @@ jobs:
             $false
           }
 
-          Write-Output "::set-output name=found::$(([string]${LabelFound}).ToLower())"
+          "found=$(([string]${LabelFound}).ToLower())" >> $env:GITHUB_OUTPUT
 
       - name: Create Windows Qt package
         if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
@@ -638,8 +638,8 @@ jobs:
       - name: Get Metadata
         id: metadata
         run: |
-          echo "::set-output name=version::${GITHUB_REF/refs\/tags\//}"
-          echo "::set-output name=date::$(date +"%Y-%m-%d")"
+          echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          echo "date=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
 
       - name: 'Download build artifacts'
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
GitHub Actions has deprecated set-output. Replace usages of set-output in stdout with the new syntax to save the output to the new environment variable.

See:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want deprecation warnings hiding real issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It hasn't. This was written by following documentation. A CI run will be the test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
