### PR TITLE
deps.windows: Add Jansson to Windows deps

### DIFF
--- a/deps.windows/30-jansson.ps1
+++ b/deps.windows/30-jansson.ps1
@@ -1,0 +1,66 @@
+param(
+    [string] $Name = 'jansson',
+    [string] $Version = '2.14',
+    [string] $Uri = 'https://github.com/akheron/jansson.git',
+    [string] $Hash = '684e18c927e89615c2d501737e90018f4930d6c5'
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Clean {
+    Set-Location $Path
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $OnOff = @('OFF', 'ON')
+    $Options = @(
+        $CmakeOptions
+        '-DJANSSON_EXAMPLES=OFF'
+        '-DJANSSON_BUILD_DOCS=OFF'
+        "-DJANSSON_BUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])"
+        '-DJANSSON_WITHOUT_TESTS=ON'
+    )
+
+    Invoke-External cmake -S . -B "build_${Target}" @Options
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--install', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $Configuration -match "(Release|MinSizeRel)" ) {
+        $Options += '--strip'
+    }
+
+    Invoke-External cmake @Options
+}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add Jansson 2.14 to the Windows deps. Mimic our existing in-tree build options as much as possible, except don't override JANSSON_STATIC_CRT. The default value is OFF, which in turn means /MT and /MTd are NOT set, which is seemingly what we want. Our in-tree build overrides JANSSON_STATIC_CRT to ON, but then also forces /MT and /MTd to NOT be set. JANSSON_STATIC_CRT only controls whether or not those flags are set, so just leave it OFF.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Jansson adds 20-30 seconds to the CMake configuration time of my local builds, and adds 40-60 seconds on CI builds. If we prebuild it, we can avoid that needless expenditure of time. Want to pull in-tree deps out of the obs-studio tree where feasible.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally and I can build Release obs-studio just fine. However, trying to build in Debug results in an LNK4098 error:
```
15>   Creating library C:/code/obsproject/obs-studio/build64/libobs/Debug/obs.lib and object C:/code/obsproject/obs-studio/build64/libobs/Debug/obs.exp
15>LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library
15>LINK : error LNK1218: warning treated as error; no output file generated
15>Done building project "libobs.vcxproj" -- FAILED.

21>   Creating library C:/code/obsproject/obs-studio/build64/plugins/rtmp-services/Debug/rtmp-services.lib and object C:/code/obsproject/obs-studio/build64/plugins/rtmp-services/Debug/rtmp-services.exp
21>LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library
21>LINK : error LNK1218: warning treated as error; no output file generated
21>Done building project "rtmp-services.vcxproj" -- FAILED.
```
We have previously suppressed this warning in https://github.com/obsproject/obs-studio/pull/6774 and https://github.com/obsproject/obs-studio/pull/6723. I don't know if that's what we should do in this case as well, or if there's a more correct solution.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
