### PR TITLE
utils.pwsh: Fix issues with Powershell 7.3.0

### DIFF
--- a/utils.pwsh/Invoke-DevShell.ps1
+++ b/utils.pwsh/Invoke-DevShell.ps1
@@ -51,8 +51,9 @@ Enter-VsDevShell @_Params
 
 Set-Location ${BuildPath}
 & ${BuildCommand}
-if ( `$LASTEXITCODE -ne 0 ) {
-    throw "${BuildCommand} failed with exit code `${LASTEXITCODE}
+
+if ( ! ( `$? ) ) {
+    throw "$(${BuildCommand} -replace '"','`"') failed."
 }
 "@
 
@@ -69,11 +70,11 @@ if ( `$LASTEXITCODE -ne 0 ) {
 
     & $PowerShellCommand -Command $DevShellCommand
 
-    $Result = $LASTEXITCODE
+    $Result = $?
 
     $ErrorActionPreference = $_EAP
 
-    if ( $Result -ne 0 ) {
-        throw "${PowerShellCommand} exited with non-zero code ${Result}."
+    if ( ! ( $Result ) ) {
+        throw "${PowerShellCommand} exited with error."
     }
 }

--- a/utils.pwsh/Utils-Patch.ps1
+++ b/utils.pwsh/Utils-Patch.ps1
@@ -45,8 +45,11 @@ function Revert-Patch {
         $(if ( $DryRun ) { "--dry-run" })
         $(if ( $VerbosePreference -eq 'Continue' ) { "--verbose" })
         '-i', $PatchFile
-        $(if ( $Silent ) { " > NUL" })
     )
+
+    if ( ( $PSVersionTable.PSVersion -lt '7.3.0' ) -and ( $Silent ) ) {
+        $Params += @(" > NUL")
+    }
 
     Log-Information "Reverting patch $([System.IO.Path]::GetFileName($PatchFile))"
     Run-PatchExe @Params
@@ -75,8 +78,11 @@ function Apply-Patch {
         $(if ( $DryRun ) { "--dry-run" })
         $(if ( $VerbosePreference -eq 'Continue' ) { "--verbose" })
         '-i', $PatchFile
-        $(if ( $Silent ) { " > NUL" })
     )
+
+    if ( ( $PSVersionTable.PSVersion -lt '7.3.0' ) -and ( $Silent ) ) {
+        $Params += @(" > NUL")
+    }
 
     Log-Information "Applying patch $([System.IO.Path]::GetFileName($PatchFile))"
     Run-PatchExe @Params


### PR DESCRIPTION
### Description
Fixes issues in `Invoke-DevShell` and `Utils-Patch` due to PowerShell 7.3.0 becoming available on Windows runners.

### Motivation and Context
Fix Windows build jobs on GitHub Actions.

### How Has This Been Tested?
Tested updated scripts on local Windows 11 VM.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
