### PR TITLE
macOS: Fix shared library symlinks breaking Xcode bundle composition

### DIFF
--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -162,12 +162,28 @@ EOF"
 fixup() {
   cd "${dir}"
 
-  if [[ ${target} == "windows-x"* ]] {
-    log_info "Fixup (%F{3}${target}%f)"
-    if (( shared_libs )) {
-      mkdir -p ${target_config[output_dir]}/bin
-      autoload -Uz create_importlibs
-      create_importlibs ${target_config[output_dir]}/bin/libmbed*.dll
-    }
+  case ${target} {
+    macos*)
+      if (( shared_libs )) {
+        log_info "Fixup (%F{3}${target}%f)"
+        pushd "${target_config[output_dir]}"/lib
+
+        for file (libmbed(crypto|tls|x509).dylib(@)) {
+          if [[ -h "${file}" ]] {
+            rm "${file}"
+            ln -s "${file:r}".*.dylib(.) "${file}"
+          }
+        }
+        popd
+      }
+      ;;
+    windows*)
+      log_info "Fixup (%F{3}${target}%f)"
+      if (( shared_libs )) {
+        mkdir -p ${target_config[output_dir]}/bin
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libmbed*.dll
+      }
+      ;;
   }
 }

--- a/deps.ffmpeg/60-srt.zsh
+++ b/deps.ffmpeg/60-srt.zsh
@@ -121,13 +121,26 @@ fixup() {
 
   rm ${target_config[output_dir]}/bin/(srt-ffp*)(N)
 
-  if [[ ${target} == "windows-x"* ]] {
-    log_info "Fixup (%F{3}${target}%f)"
-    if (( shared_libs )) {
-      autoload -Uz create_importlibs
-      create_importlibs ${target_config[output_dir]}/bin/libsrt*.dll
-    }
+  case ${target} {
+    macos*)
+      if (( shared_libs )) {
+        log_info "Fixup (%F{3}${target}%f)"
+        pushd "${target_config[output_dir]}"/lib
+        if [[ -h libsrt.dylib ]] {
+          rm libsrt.dylib
+          ln -s libsrt.*.dylib(.) libsrt.dylib
+        }
+        popd
+      }
+      ;;
+    windows*)
+      log_info "Fixup (%F{3}${target}%f)"
+      if (( shared_libs )) {
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libsrt*.dll
+      }
 
-    autoload -Uz restore_dlls && restore_dlls
+      autoload -Uz restore_dlls && restore_dlls
+      ;;
   }
 }

--- a/deps.macos/30-jansson.zsh
+++ b/deps.macos/30-jansson.zsh
@@ -65,3 +65,21 @@ install() {
   cd "${dir}"
   progress cmake ${args}
 }
+
+fixup() {
+  cd "${dir}"
+
+  case ${target} {
+    macos*)
+      if (( shared_libs )) {
+        log_info "Fixup (%F{3}${target}%f)"
+        pushd "${target_config[output_dir]}"/lib
+        if [[ -h libjansson.dylib ]] {
+          rm libjansson.dylib
+          ln -s libjansson.*.dylib(.) libjansson.dylib
+        }
+        popd
+      }
+      ;;
+  }
+}


### PR DESCRIPTION
### Description
Fixes broken Xcode bundle composition by removing symlink chains from unversioned dynamic library names.

### Motivation and Context
CMake by default generates dynamic libraries with a full semver filename and two symlinks:

* A major version symlink pointing to the semver file
* An unversioned symlink pointing to the major version symlink

Xcode's file copy step used to move Frameworks into an app bundle only resolves a single level of symlinks, so with this setup a symlink is copied into the bundle, which then fails at the codesigning step.

Behaviour has been reported to CMake (https://gitlab.kitware.com/cmake/cmake/-/issues/24174#note_1277980) as well as Apple. These fixups should mitigate this in the short term.

### How Has This Been Tested?
Built all fixed libraries locally and checked generated symlinks.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
