### PR TITLE
deps.windows: Remove GL/LTCG from SpeexDSP CMake patch

### DIFF
--- a/deps.windows/30-speexdsp.ps1
+++ b/deps.windows/30-speexdsp.ps1
@@ -6,7 +6,7 @@ param(
     [array] $Patches = @(
         @{
             PatchFile = "${PSScriptRoot}/patches/speexdsp/0001-Add-CMakeLists.patch"
-            HashSum = '3790e04820570ce911961c11291e4310583d41ad5f14a1dc5b5cc83485458c46'
+            HashSum = 'a7e625bdf83fea2c0d0a215e7e04a44c0ac0f892217895481723e33e0008ba18'
         }
     )
 )

--- a/deps.windows/patches/speexdsp/0001-Add-CMakeLists.patch
+++ b/deps.windows/patches/speexdsp/0001-Add-CMakeLists.patch
@@ -1,6 +1,6 @@
---- null       			   2022-07-07 23:00:00.000000000 -0400
-+++ ./CMakeLists.txt       2022-07-07 23:00:00.000000000 -0400
-@@ -0,0 +1,95 @@
+--- null       			   2022-11-22 18:00:00.000000000 -0500
++++ ./CMakeLists.txt       2022-11-22 18:00:00.000000000 -0500
+@@ -0,0 +1,90 @@
 +cmake_minimum_required(VERSION 3.16)
 +
 +project(speexdsp)
@@ -78,11 +78,6 @@
 +        PUBLIC
 +            "include"
 +    )
-+
-+    set_target_properties(speexdsp PROPERTIES
-+        COMPILE_FLAGS_RELEASE "/GL")
-+    set_target_properties(speexdsp PROPERTIES
-+        STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
 +
 +    include(CheckIPOSupported)
 +    check_ipo_supported(RESULT HasIPOSupport)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This caused a build failure recently, and we determined that it's safer to build without these options.

We apparently have been lucky enough to never run into this failure since this was added back in #79.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want build failures.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Has not been tested yet. CI should at least tell us if SpeexDSP will build. Will try to test before merging unless others think this is fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
