### PR TITLE
deps.windows: Explicitly disable ZLIB with curl

### DIFF
--- a/deps.windows/30-curl.ps1
+++ b/deps.windows/30-curl.ps1
@@ -38,6 +38,7 @@ function Configure {
         '-DBUILD_TESTING=OFF'
         '-DCURL_USE_LIBSSH2=OFF'
         '-DCURL_USE_SCHANNEL=ON'
+        '-DCURL_ZLIB=OFF'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Previously, curl would attempt to find ZLIB, and could continue even if ZLIB was not fully found. This could result in a scenario where ZLIB includes were found, but ZLIB libraries were not found, and the curl build would continue and succeed anyway. Examining previous builds, it seems that this was the case for our dependencies.

A recent build failure on CI (windows-2022, version 20221120.1) had CMake find the x64 ZLIB libraries from CI's Strawberry Perl install location, which caused a build failure for the x86 dependencies due to mismatched architectures. The version of Perl did not change between the image versions, so I suspect some other change, possibly in CMake (or curl), that caused it to suddenly find the libraries.

Since ZLIB was not actually being used, let's simply disable it explicitly.

References:
https://github.com/curl/curl/commit/f21cc62832a9d5c521d10da9177b075bfed43f2f
https://github.com/actions/runner-images/blob/win22/20221027.1/images/win/Windows2022-Readme.md
https://github.com/actions/runner-images/blob/win22/20221120.1/images/win/Windows2022-Readme.md

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Want deps to build on CI.

https://github.com/obsproject/obs-deps/actions/runs/3537925796/jobs/5938322578

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

CI is the test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
