### PR TITLE
utils.pwsh: Ignore Strawberry Perl default path

### DIFF
--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -82,7 +82,7 @@ function Configure {
         $QtBuildConfiguration = '-release'
     }
 
-    $BuildCommand = "..\..\..\qt6\configure -opensource -confirm-license ${QtBuildConfiguration} -nomake examples -nomake tests -schannel -no-dbus -no-freetype -no-icu -no-openssl -no-feature-androiddeployqt -no-feature-pdf -no-feature-printsupport -no-feature-qmake -no-feature-sql -no-feature-testlib -no-feature-windeployqt -DQT_NO_PDF -DCMAKE_IGNORE_PREFIX_PATH=C:/Strawberry/c -prefix ${BuildPath}"
+    $BuildCommand = "..\..\..\qt6\configure -opensource -confirm-license ${QtBuildConfiguration} -nomake examples -nomake tests -schannel -no-dbus -no-freetype -no-icu -no-openssl -no-feature-androiddeployqt -no-feature-pdf -no-feature-printsupport -no-feature-qmake -no-feature-sql -no-feature-testlib -no-feature-windeployqt -qt-doubleconversion -qt-pcre -qt-zlib -qt-libjpeg -qt-libpng -qt-libmd4c -qt-tiff -qt-webp -DQT_NO_PDF -DCMAKE_IGNORE_PREFIX_PATH=C:/Strawberry/c -prefix ${BuildPath}"
 
     $Params = @{
         BasePath = (Get-Location | Convert-Path)

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -82,7 +82,7 @@ function Configure {
         $QtBuildConfiguration = '-release'
     }
 
-    $BuildCommand = "..\..\..\qt6\configure -opensource -confirm-license ${QtBuildConfiguration} -nomake examples -nomake tests -schannel -no-dbus -no-freetype -no-icu -no-openssl -no-feature-androiddeployqt -no-feature-pdf -no-feature-printsupport -no-feature-qmake -no-feature-sql -no-feature-testlib -no-feature-windeployqt -DQT_NO_PDF -prefix ${BuildPath}"
+    $BuildCommand = "..\..\..\qt6\configure -opensource -confirm-license ${QtBuildConfiguration} -nomake examples -nomake tests -schannel -no-dbus -no-freetype -no-icu -no-openssl -no-feature-androiddeployqt -no-feature-pdf -no-feature-printsupport -no-feature-qmake -no-feature-sql -no-feature-testlib -no-feature-windeployqt -DQT_NO_PDF -DCMAKE_IGNORE_PREFIX_PATH=C:/Strawberry/c -prefix ${BuildPath}"
 
     $Params = @{
         BasePath = (Get-Location | Convert-Path)

--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -48,6 +48,7 @@ function Setup-BuildParameters {
         '-G', $VisualStudioId
         "-DCMAKE_INSTALL_PREFIX=$($script:ConfigData.OutputPath)"
         "-DCMAKE_PREFIX_PATH=$($script:ConfigData.OutputPath)"
+        "-DCMAKE_IGNORE_PREFIX_PATH=C:\Strawberry\c"
         "-DCMAKE_BUILD_TYPE=${script:Configuration}"
         '--no-warn-unused-cli'
     )


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The Strawberry Perl installation is poisoning all of our native Windows builds (notably, FreeType, curl, PCRE, and Qt6). For now, ignoring its default installation path is likely the easiest solution.

Also, force Qt6 Windows builds to use bundled 3rd party libraries when possible (e.g., ZLIB, libpng, libjpeg).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want CI builds to stop failing.

While I have PRs ready for tightening up the FreeType and curl builds (FreeType manages to succeed regardless, the curl PR seemed to work), PCRE was the next to fail. We may want to continue fixing them individually one by one, and then apply this for future cases, or perhaps we don't want this, and we'd rather fix them all individually. In any case, I'm opening this PR to provide us the option of which path to choose.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
CI is the test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
