### PR TITLE
deps.macos: Remove unnecessary fixup for Windows target

### DIFF
--- a/deps.macos/50-libpng.zsh
+++ b/deps.macos/50-libpng.zsh
@@ -111,17 +111,3 @@ install() {
   cd "${dir}"
   progress cmake ${args}
 }
-
-fixup() {
-  cd "${dir}"
-
-  if [[ ${target} == "windows-x"* ]] {
-    log_info "Fixup (%F{3}${target}%f)"
-    if (( shared_libs )) {
-      autoload -Uz create_importlibs
-      create_importlibs ${target_config[output_dir]}/bin/libpng*.dll(:a)
-    }
-
-    rm ${target_config[output_dir]}/bin/(libpng*-config|png*fix*)(N)
-  }
-}


### PR DESCRIPTION
### Description
Remove unnecessary fixup function for Windows target on macOS deps script.

### Motivation and Context
The fixup function is a bad copy paste error that does nothing on deps for macOS.

### How Has This Been Tested?
Let's see if the CI likes this. Shouldn't be too bad.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
