### PR TITLE
Update obs-deps for CMake 3.0 macOS update

### DIFF
--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -98,6 +98,9 @@ package() {
     if [[ -d share ]] rm -rf share/^(swig)(N)
     if [[ -d cmake ]] rm -rf cmake
     if [[ -d man ]] rm -rf man
+
+    mkdir -p share/obs-deps
+    echo "${current_date}" >! share/obs-deps/VERSION
   }
 
   log_status "Create archive ${filename}"

--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -85,13 +85,13 @@ package() {
   if [[ ${PACKAGE_NAME} != 'qt'* ]] {
     log_status "Cleanup unnecessary files"
 
-    rm -rf lib/^(*.dylib|libajantv*|*.so*|*.lib)(N)
+    rm -rf lib/^(*.dylib|libajantv*|*.a|*.so*|*.lib|cmake)(N)
     rm -rf bin/^(*.exe|*.dll|*.pdb|swig)(N)
 
     if [[ -f bin/swig ]] {
       swig_lib=(share/swig/*(/))
       pushd ${swig_lib:h}
-      ln -s ${swig_lib:t} CURRENT
+      ln -sf ${swig_lib:t} CURRENT
       popd
     }
 

--- a/deps.ffmpeg/20-opus.zsh
+++ b/deps.ffmpeg/20-opus.zsh
@@ -103,12 +103,15 @@ install() {
 fixup() {
   cd "${dir}"
 
-  if [[ ${target} == "windows-x"* ]] {
-    if (( shared_libs )) {
-      log_info "Fixup (%F{3}${target}%f)"
-      autoload -Uz create_importlibs
-      create_importlibs ${target_config[output_dir]}/bin/libopus*.dll(:a)
-      autoload -Uz restore_dlls && restore_dlls
-    }
+  case ${target} {
+    macos-*|linux-*) rm -rf "${target_config[output_dir]}"/lib/cmake/Opus ;;
+    windows-*)
+      if (( shared_libs )) {
+        log_info "Fixup (%F{3}${target}%f)"
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libopus*.dll(:a)
+        autoload -Uz restore_dlls && restore_dlls
+      }
+      ;;
   }
 }

--- a/deps.ffmpeg/30-libogg.zsh
+++ b/deps.ffmpeg/30-libogg.zsh
@@ -111,11 +111,14 @@ install() {
 fixup() {
   cd "${dir}"
 
-  if [[ ${target} == "windows-x"* ]] {
-    if (( shared_libs )) {
-      log_info "Fixup (%F{3}${target}%f)"
-      autoload -Uz create_importlibs
-      create_importlibs ${target_config[output_dir]}/bin/libogg*.dll
-    }
+  case ${target} {
+    macos-*|linux-*) rm -rf "${target_config[output_dir]}"/lib/cmake/Ogg ;;
+    windows-*)
+      if (( shared_libs )) {
+        log_info "Fixup (%F{3}${target}%f)"
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libogg*.dll
+      }
+      ;;
   }
 }

--- a/deps.ffmpeg/30-libvorbis.zsh
+++ b/deps.ffmpeg/30-libvorbis.zsh
@@ -110,11 +110,14 @@ install() {
 fixup() {
   cd "${dir}"
 
-  if [[ ${target} == "windows-x"* ]] {
-    if (( shared_libs )) {
-      log_info "Fixup (%F{3}${target}%f)"
-      autoload -Uz create_importlibs
-      create_importlibs ${target_config[output_dir]}/bin/libvorbis*.dll(:a)
-    }
+  case ${target} {
+    macos-*|linux-*) rm -rf "${target_config[output_dir]}"/lib/cmake/Vorbis ;;
+    windows-*)
+      if (( shared_libs )) {
+        log_info "Fixup (%F{3}${target}%f)"
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libvorbis*.dll(:a)
+      }
+      ;;
   }
 }

--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -175,6 +175,9 @@ fixup() {
           }
         }
         popd
+
+        autoload -Uz fix_rpaths
+        fix_rpaths "${target_config[output_dir]}"/lib/libmbed*.dylib(.)
       }
       ;;
     windows*)

--- a/deps.ffmpeg/60-srt.zsh
+++ b/deps.ffmpeg/60-srt.zsh
@@ -130,6 +130,9 @@ fixup() {
           ln -s libsrt.*.dylib(.) libsrt.dylib
         }
         popd
+
+        autoload -Uz fix_rpaths
+        fix_rpaths "${target_config[output_dir]}"/lib/libsrt*.dylib(.)
       }
       ;;
     windows*)

--- a/deps.ffmpeg/70-librist.zsh
+++ b/deps.ffmpeg/70-librist.zsh
@@ -133,8 +133,8 @@ fixup() {
     log_info "Fixup (%F{3}${target}%f)"
     case ${target} {
       macos*)
-          autoload -Uz fix_rpaths
-          fix_rpaths "${target_config[output_dir]}"/lib/librist*.dylib(.)
+        autoload -Uz fix_rpaths
+        fix_rpaths "${target_config[output_dir]}"/lib/librist*.dylib(.)
 
         strip_tool=strip
         strip_files=("${target_config[output_dir]}"/lib/librist*.dylib(.))

--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -60,7 +60,6 @@ config() {
     macos-*)
       local -A hide_libs=(
         xz libzlma
-        sdl libSDL2
       )
 
       local lib lib_name lib_file
@@ -203,7 +202,7 @@ config() {
     --disable-static
     --disable-libjack
     --disable-indev=jack
-    --disable-outdev=sdl
+    --disable-sdl2
     --disable-doc
     --disable-postproc
   )

--- a/deps.macos/10-speexdsp.zsh
+++ b/deps.macos/10-speexdsp.zsh
@@ -127,6 +127,8 @@ fixup() {
       if (( shared_libs )) {
         log_info "Fixup (%F{3}${target}%f)"
         fix_rpaths "${target_config[output_dir]}"/lib/libspeexdsp*.dylib
+      } else {
+        rm "${target_config[output_dir]}"/lib/libspeexdsp*.dylib(N)
       }
       ;;
   }

--- a/deps.macos/30-jansson.zsh
+++ b/deps.macos/30-jansson.zsh
@@ -79,6 +79,13 @@ fixup() {
           ln -s libjansson.*.dylib(.) libjansson.dylib
         }
         popd
+
+        autoload -Uz fix_rpaths
+        fix_rpaths "${target_config[output_dir]}"/lib/libjansson*.dylib
+
+        for file ("${target_config[output_dir]}"/lib/cmake/jansson/janssonTargets-*.cmake) {
+          sed -i '' 's/libjansson.*.dylib/libjansson.dylib/' "${file}"
+        }
       }
       ;;
   }

--- a/deps.macos/40-luajit.zsh
+++ b/deps.macos/40-luajit.zsh
@@ -128,7 +128,12 @@ fixup() {
     macos*)
       if (( shared_libs )) {
         log_info "Fixup (%F{3}${target}%f)"
-        fix_rpaths "${target_config[output_dir]}"/lib/libluajit*.dylib
+        for file ("${target_config[output_dir]}"/lib/libluajit-5.1*.dylib(.)) {
+          install_name_tool -id "@rpath/libluajit-5.1.dylib" "${file}"
+          log_status "Fixed id of ${file##*/}"
+        }
+      } else {
+        rm "${target_config[output_dir]}"/lib/libluajit-5.1*.dylib(N)
       }
       ;;
   }

--- a/deps.macos/50-libpng.zsh
+++ b/deps.macos/50-libpng.zsh
@@ -10,6 +10,8 @@ local -a patches=(
   f9ce2b5f8b63ef6caa9ab0195d27c52563652da56ab53956ffa51b34ff90ad4d"
 )
 
+local -i shared_libs=0
+
 ## Build Steps
 setup() {
   log_info "Setup (%F{3}${target}%f)"
@@ -110,4 +112,22 @@ install() {
 
   cd "${dir}"
   progress cmake ${args}
+}
+
+fixup() {
+  cd "${dir}"
+
+  log_info "Fixup (%F{3}${target}%f)"
+  case ${target} {
+    macos*)
+      if [[ "${config}" == "Debug" ]] {
+        local _file
+        local -a _debug_files
+        _debug_files=("${target_config[output_dir]}"/lib/libpng16d.*(N))
+        for _file (${_debug_files}) {
+          mv "${_file}" "${_file//d./.}"
+        }
+      }
+      ;;
+  }
 }

--- a/deps.macos/60-freetype.zsh
+++ b/deps.macos/60-freetype.zsh
@@ -6,6 +6,8 @@ local version='2.12.1'
 local url='https://downloads.sourceforge.net/project/freetype/freetype2/2.12.1/freetype-2.12.1.tar.xz'
 local hash="${0:a:h}/checksums/freetype-2.12.1.tar.xz.sha256"
 
+local -i shared_libs=1
+
 ## Build Steps
 setup() {
   log_info "Setup (%F{3}${target}%f)"

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -87,6 +87,7 @@ config() {
   local -a common_cmake_flags=(
     ${cmake_flags}
     -DBUILD_SHARED_LIBS="${_onoff[(( shared_libs + 1 ))]}"
+    -DFEATURE_rpath="${_onoff[(( shared_libs + 1 ))]}"
   )
   if (( ${+commands[ccache]} )) common_cmake_flags+=(-DQT_USE_CCACHE=ON)
 
@@ -116,7 +117,6 @@ config() {
     -DFEATURE_printpreviewdialog=OFF
     -DFEATURE_printpreviewwidget=OFF
     -DFEATURE_qmake=OFF
-    -DFEATURE_rpath=ON
     -DFEATURE_sql=OFF
     -DFEATURE_system_zlib=ON
     -DINPUT_libjpeg=qt

--- a/utils.zsh/20-host.zsh
+++ b/utils.zsh/20-host.zsh
@@ -38,7 +38,6 @@ _setup_macos() {
 
     local -a restore_libs=(
       'xz lzma'
-      'sdl2 SDL2'
       zstd
       'libtiff tiff'
       webp

--- a/utils.zsh/functions/fix_rpaths
+++ b/utils.zsh/functions/fix_rpaths
@@ -29,12 +29,13 @@ for lib ($@) {
     log_debug "Working on ${linked_lib}"
     linked_lib=${linked_lib//[[:space:]]/}
     if [[ ${linked_lib:A:h} == "${lib:A:h}" ]] {
-
-      install_name_tool -change "${linked_lib}" "@rpath/${linked_lib##*/}" "${lib}"
+      install_name_tool -change "${linked_lib}" "@rpath/${${linked_lib##*/}%%.*}.dylib" "${lib}"
       log_status "Fixed library path ${linked_lib:A:h} in ${lib##*/}"
+    } elif [[ ${${linked_lib:A:h}##*/} == '@rpath' ]] {
+      install_name_tool -change "${linked_lib}" "@rpath/${${linked_lib##*/}%%.*}.dylib" "${lib}"
     }
   done <<< "${libs}"
 
-  install_name_tool -id "@rpath/${lib_basename}" "${lib}"
+  install_name_tool -id "@rpath/${lib_name}.dylib" "${lib}"
   log_status "Fixed id of ${lib##*/}"
 }


### PR DESCRIPTION
### Description
Fixes generated macOS libraries to not use versioned SONAMEs if possible and fix MACHO header `id` values to match those unversioned variants.

### Motivation and Context
Using versioned library names is common on Linux to discern between the _actual_ version of a library (`some_lib.so.4.5.1`), the compatibility version (usually the major version `some_lib.so.4`) that should be API-compatible, and a fallback name (`some_lib.so`), with the latter two pointing to the actual library via symlinking.

macOS uses two values in its `LC_ID_DYLIB` header (`current` and `compatibility`) which are used by its library loader to check if a library is compatible - the actual file names are not used.

A binary should link to a library (`some_lib.dylib`) via the `LC_LOAD_DYLIB` header, which itself also contains `current` and `compatibility` values, which is used by the library loader to check if a found file matches the requirements.

To that end it is more desirable to create libraries without any versioned filenames or `id`s and resolve compatibility with the header values. Alas most libraries used by OBS are designed for Linux and not macOS, so they use versioned SONAMEs to generate output names and the `install_name` given to the linker on macOS.

These changes fix not only the `rpath` entries on all libraries, but also the `id` values of libraries and local dependency to create a "clean" dependency tree on macOS.

**EDIT**: Important to note that this does _not_ change the versions of the generated libraries, just the id *name* is changed.

### How Has This Been Tested?
Built dependencies locally and compiled OBS from master tree as well as with upcoming Xcode-focused CMake update, both generated application bundles ran and resolved libraries without issue.

This should not break on master, as the current build system copies all libraries (actual library and versioned+unversioned symlinks) into the application bundle, so even with an unversioned `id`, the actual library will be found.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
