### PR TITLE
Revert "deps.qt: Update Qt6 to Qt 6.4.1 for Windows"

### DIFF
--- a/deps.qt/checksums/qtbase-everywhere-src-6.3.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtbase-everywhere-src-6.3.1.tar.xz.sha256
@@ -1,0 +1,1 @@
+0a64421d9c2469c2c48490a032ab91d547017c9cc171f3f8070bc31888f24e03  qtbase-everywhere-src-6.3.1.tar.xz

--- a/deps.qt/checksums/qtbase-everywhere-src-6.4.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtbase-everywhere-src-6.4.1.tar.xz.sha256
@@ -1,1 +1,0 @@
-532ad71cc0f9c8f7cb92766c47bc3d23263c60876becd9053802f9727af24fae  qtbase-everywhere-src-6.4.1.tar.xz

--- a/deps.qt/checksums/qtimageformats-everywhere-src-6.3.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtimageformats-everywhere-src-6.3.1.tar.xz.sha256
@@ -1,0 +1,1 @@
+ad0312b8dfbbb67f729bfadbfcd47246ee4a128b717731ba158c41d01fde212f  qtimageformats-everywhere-src-6.3.1.tar.xz

--- a/deps.qt/checksums/qtimageformats-everywhere-src-6.4.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtimageformats-everywhere-src-6.4.1.tar.xz.sha256
@@ -1,1 +1,0 @@
-5e85e73eb2fa8e6f4287eab1d6bcc852ae7b3b613311a4147ec4a08f62454de6  qtimageformats-everywhere-src-6.4.1.tar.xz

--- a/deps.qt/checksums/qtmultimedia-everywhere-src-6.3.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtmultimedia-everywhere-src-6.3.1.tar.xz.sha256
@@ -1,0 +1,1 @@
+7e03242aadd634ff2d9fcf08948290f03da3d9a5012369d908da89f82b1d7336  qtmultimedia-everywhere-src-6.3.1.tar.xz

--- a/deps.qt/checksums/qtmultimedia-everywhere-src-6.4.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtmultimedia-everywhere-src-6.4.1.tar.xz.sha256
@@ -1,1 +1,0 @@
-c086d43a026e6090971fd7a697ef8370c5c455115240609cd08d5e2f840dbaaf  qtmultimedia-everywhere-src-6.4.1.tar.xz

--- a/deps.qt/checksums/qtshadertools-everywhere-src-6.3.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtshadertools-everywhere-src-6.3.1.tar.xz.sha256
@@ -1,0 +1,1 @@
+59b77176961528cc7b0c9325134655e273aa87b4cb386c0f4683d8f2852e435a  qtshadertools-everywhere-src-6.3.1.tar.xz

--- a/deps.qt/checksums/qtshadertools-everywhere-src-6.4.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtshadertools-everywhere-src-6.4.1.tar.xz.sha256
@@ -1,1 +1,0 @@
-6bc1748326088c87f562fa3a68140e33fde162fd1333fbfecb775aeb66114504  qtshadertools-everywhere-src-6.4.1.tar.xz

--- a/deps.qt/checksums/qtsvg-everywhere-src-6.3.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtsvg-everywhere-src-6.3.1.tar.xz.sha256
@@ -1,0 +1,1 @@
+7b19f418e6f7b8e23344082dd04440aacf5da23c5a73980ba22ae4eba4f87df7  qtsvg-everywhere-src-6.3.1.tar.xz

--- a/deps.qt/checksums/qtsvg-everywhere-src-6.4.1.tar.xz.sha256
+++ b/deps.qt/checksums/qtsvg-everywhere-src-6.4.1.tar.xz.sha256
@@ -1,1 +1,0 @@
-5e5345c5941567db883f9daf8ab25108c6f3a527453b1a13c62290849bce9ce5  qtsvg-everywhere-src-6.4.1.tar.xz

--- a/deps.qt/patches/Qt6/win/0001-QTBUG-86344.patch
+++ b/deps.qt/patches/Qt6/win/0001-QTBUG-86344.patch
@@ -1,0 +1,17 @@
+Submodule qtbase contains modified content
+diff --git a/qtbase/src/widgets/styles/qwindowsstyle.cpp b/qtbase/src/widgets/styles/qwindowsstyle.cpp
+index 39fabd1218..a2b4cc0ccc 100644
+--- a/qtbase/src/widgets/styles/qwindowsstyle.cpp
++++ b/qtbase/src/widgets/styles/qwindowsstyle.cpp
+@@ -409,7 +409,10 @@ static QScreen *screenOf(const QWidget *w)
+ // and account for secondary screens with differing logical DPI.
+ qreal QWindowsStylePrivate::nativeMetricScaleFactor(const QWidget *widget)
+ {
+-    qreal result = qreal(1) / QWindowsStylePrivate::devicePixelRatio(widget);
++    const QPlatformScreen *screen = screenOf(widget)->handle();
++    const qreal scale = screen ? (screen->logicalDpi().first / screen->logicalBaseDpi().first)
++                               : QWindowsStylePrivate::appDevicePixelRatio();
++    qreal result = qreal(1) / scale;
+     if (QGuiApplicationPrivate::screen_list.size() > 1) {
+         const QScreen *primaryScreen = QGuiApplication::primaryScreen();
+         const QScreen *screen = screenOf(widget);

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -1,8 +1,14 @@
 param(
     [string] $Name = 'qt6',
-    [string] $Version = '6.4.1',
+    [string] $Version = '6.3.1',
     [string] $Uri = 'https://github.com/qt/qt5.git',
-    [string] $Hash = '19263d39aad47771e53d3cf70d286d049412f589'
+    [string] $Hash = 'c3d2dfa229f87374fc5919b5c44606445cf94bd8',
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/Qt6/win/0001-QTBUG-86344.patch"
+            HashSum = "688E7787CEA28047DF819AA00E16A81CA3BB7E331E7620268CCD38D1D533B4ED"
+        }
+    )
 )
 
 # References:

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -2,8 +2,8 @@ autoload -Uz log_debug log_error log_info log_status log_output
 
 ## Dependency Information
 local name='qt6'
-local version=6.4.1
-local url='https://download.qt.io/official_releases/qt/6.4/6.4.1'
+local version=6.3.1
+local url='https://download.qt.io/official_releases/qt/6.3/6.3.1'
 local hash="${0:a:h}/checksums"
 local -a patches=()
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This reverts commit 0b22ceded4e033711e07cdd5169f7d686e2a5892.

This rolls back Qt on Windows from 6.4.1 to 6.3.1 due to a [previously mentioned debug assert](https://github.com/obsproject/obs-deps/pull/141#issuecomment-1316439656) that has not been resolved. As far as I know, the debug assert only occurs on Windows in VS2022, but it was also recommended to roll back Qt on macOS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We decided that if this wasn't resolved in time for OBS 29, that we'd roll it back.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OBS 28.1 ran on Qt 6.3.1.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
