### PR TITLE
deps.windows: Add static ZLib for updater

### DIFF
--- a/deps.windows/60-zlib.ps1
+++ b/deps.windows/60-zlib.ps1
@@ -1,0 +1,59 @@
+param(
+    [string] $Name = 'zlib',
+    [string] $Version = '1.2.12',
+    [string] $Uri = 'https://github.com/madler/zlib.git',
+    [string] $Hash = '21767c654d31d2dccdde4330529775c6c5fd5389'
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $OnOff = @('OFF', 'ON')
+    $Options = @(
+        $CmakeOptions
+        '-DBUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])'
+        '-DCMAKE_C_FLAGS_RELEASE="/MT"'
+        '-DCMAKE_C_FLAGS_RELWITHDEBINFO="/MT"'
+        '-DCMAKE_C_FLAGS_DEBUG="/MTd"'
+    )
+    Log-Information "Shared: $($OnOff[$script:Shared.isPresent])"
+
+    Invoke-External cmake -S . -B "build_${Target}" @Options
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--install', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $Configuration -match "(Release|MinSizeRel)" ) {
+        $Options += '--strip'
+    }
+
+    Invoke-External cmake @Options
+}


### PR DESCRIPTION
### Description

Adds static zlib build specifically for building the updater.

Based on Ryan's original commit, but with changes to set the correct runtime flags: https://github.com/RytoEX/obs-deps/commit/bde8f91f3a71ee16baba4f422a2e9722f8c6f133

### Motivation and Context

Make life easier for people building the updater (i.e. me) and make it possible to build it on CI going forward.

### How Has This Been Tested?

Local build and compile.

### Types of changes

- New feature (non-breaking change which adds functionality)>

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
