### PR TITLE
deps.windows: Update FreeType CMake flags

### DIFF
--- a/deps.windows/20-freetype.ps1
+++ b/deps.windows/20-freetype.ps1
@@ -25,11 +25,11 @@ function Configure {
     $Options = @(
         $CmakeOptions
         "-DBUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])"
-        '-DFT_WITH_BROTLI=OFF'
-        '-DFT_WITH_BZIP2=OFF'
-        '-DFT_WITH_HARFBUZZ=OFF'
-        '-DFT_WITH_PNG=OFF'
-        '-DFT_WITH_ZLIB=OFF'
+        '-DFT_DISABLE_BROTLI=ON'
+        '-DFT_DISABLE_BZIP2=ON'
+        '-DFT_DISABLE_HARFBUZZ=ON'
+        '-DFT_DISABLE_PNG=ON'
+        '-DFT_DISABLE_ZLIB=ON'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
FT_WITH options were replaced with FT_DISABLE and FT_REQUIRE pairs in FreeType 2.11.1. Let's update to the correct options.

References:
https://github.com/freetype/freetype/commit/1f742f05bf21234236b54f52c3ef8cc8973131b1

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Want to use the correct CMake options. We can probably reevaluate why we are using these later though.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested this locally back in November. Should still be fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
