### PR TITLE
deps.windows: Add ducible

### DIFF
--- a/deps.windows/70-ducible.ps1
+++ b/deps.windows/70-ducible.ps1
@@ -1,0 +1,109 @@
+param(
+    [string] $Name = 'ducible',
+    [string] $Version = 'v1.2.2',
+    [string] $Uri = 'https://github.com/jasonwhite/ducible.git',
+    [string] $Hash = 'b7810415529f801d98203cba00db969a6ef88a14',
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/ducible/0001-Remove-8.1-target-platform.patch"
+            HashSum = 'f45851456fd93e4491e42f108ff19e60c0de3df35f1141208c95623edae14517'
+        }
+        @{
+            PatchFile = "${PSScriptRoot}/patches/ducible/0002-Use-py-instead-of-python.patch"
+            HashSum = '5922aa7639b2a364c0f90541dc15c05dc804ace9178a40a661d360bb961584c4'
+        }
+    )
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Patch {
+    Log-Information "Patch (${Target})"
+    Set-Location $Path
+
+    $Patches | ForEach-Object {
+        $Params = $_
+        Safe-Patch @Params
+    }
+}
+
+function Clean {
+    Set-Location $Path
+
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    if ( $Configuration -match "Debug" ) {
+        $DucibleConfig = 'Debug'
+    } else {
+        $DucibleConfig = 'Release'
+    }
+
+    if ( $Target -match "x64" ) {
+        $DucibleTarget = 'x64'
+    } else {
+        $DucibleTarget = 'Win32'
+    }
+
+    $Options = @(
+        '/t:Build'
+        "/p:OutDir=.\..\..\..\build_${Target}\"
+        "/p:Configuration=${DucibleConfig}"
+        "/p:Platform=${DucibleTarget}"
+        '/p:PlatformToolset=v143'
+    )
+    # Find MSBuild command
+    $MSBUILD = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+    
+    Invoke-External $MSBUILD -m vs\vs2015\ducible.sln @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+    
+    $Params = @{
+        ErrorAction = "SilentlyContinue"
+        Path = @(
+            "$($ConfigData.OutputPath)/bin"
+        )
+        ItemType = "Directory"
+        Force = $true
+    }
+
+    New-Item @Params *> $null
+
+    $Items = @(
+        @{
+            Path = "./build_${Target}/ducible.exe"
+            Destination = "$($ConfigData.OutputPath)/bin/"
+        }
+        @{
+            Path = "./build_${Target}/pdbdump.exe"
+            Destination = "$($ConfigData.OutputPath)/bin/"
+        }
+        @{
+            Path = "./build_${Target}/ducible.pdb"
+            Destination = "$($ConfigData.OutputPath)/bin/"
+        }
+        @{
+            Path = "./build_${Target}/pdbdump.pdb"
+            Destination = "$($ConfigData.OutputPath)/bin/"
+        }
+    )
+
+    $Items | ForEach-Object {
+        $Item = $_
+        Log-Status ('{0} => {1}' -f $Item.Path, $Item.Destination)
+        Copy-Item @Item
+    }
+}

--- a/deps.windows/patches/ducible/0001-Remove-8.1-target-platform.patch
+++ b/deps.windows/patches/ducible/0001-Remove-8.1-target-platform.patch
@@ -1,0 +1,37 @@
+From c4e0a259a953eea99876ce6ef207c1acc77de0a8 Mon Sep 17 00:00:00 2001
+From: Rodney <dennis@obsproject.com>
+Date: Thu, 2 Mar 2023 13:28:55 +0100
+Subject: [PATCH] Remove 8.1 target platform
+
+---
+ vs/vs2015/ducible/ducible.vcxproj | 1 -
+ vs/vs2015/pdbdump/pdbdump.vcxproj | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/vs/vs2015/ducible/ducible.vcxproj b/vs/vs2015/ducible/ducible.vcxproj
+index 99d4ef4..a208957 100644
+--- a/vs/vs2015/ducible/ducible.vcxproj
++++ b/vs/vs2015/ducible/ducible.vcxproj
+@@ -22,7 +22,6 @@
+     <ProjectGuid>{2C07E47D-CA17-4D0A-8C9A-336DB1256938}</ProjectGuid>
+     <Keyword>Win32Proj</Keyword>
+     <RootNamespace>ducible</RootNamespace>
+-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+diff --git a/vs/vs2015/pdbdump/pdbdump.vcxproj b/vs/vs2015/pdbdump/pdbdump.vcxproj
+index cf2efc8..8f071c8 100755
+--- a/vs/vs2015/pdbdump/pdbdump.vcxproj
++++ b/vs/vs2015/pdbdump/pdbdump.vcxproj
+@@ -22,7 +22,6 @@
+     <ProjectGuid>{801F75FB-A618-42FE-ADB3-DAFD16DF799F}</ProjectGuid>
+     <Keyword>Win32Proj</Keyword>
+     <RootNamespace>ducible</RootNamespace>
+-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+-- 
+2.39.1.windows.1
+

--- a/deps.windows/patches/ducible/0002-Use-py-instead-of-python.patch
+++ b/deps.windows/patches/ducible/0002-Use-py-instead-of-python.patch
@@ -1,0 +1,93 @@
+From bc650d6c64f2f3925263cf4c5fc7587363ba4875 Mon Sep 17 00:00:00 2001
+From: Rodney <dennis@obsproject.com>
+Date: Thu, 2 Mar 2023 13:35:20 +0100
+Subject: [PATCH] Use py instead of python
+
+---
+ vs/vs2015/ducible/ducible.vcxproj | 9 ++++-----
+ vs/vs2015/pdbdump/pdbdump.vcxproj | 9 ++++-----
+ 2 files changed, 8 insertions(+), 10 deletions(-)
+
+diff --git a/vs/vs2015/ducible/ducible.vcxproj b/vs/vs2015/ducible/ducible.vcxproj
+index 99d4ef4..f49dd22 100644
+--- a/vs/vs2015/ducible/ducible.vcxproj
++++ b/vs/vs2015/ducible/ducible.vcxproj
+@@ -109,7 +108,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+@@ -135,7 +134,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+@@ -166,7 +165,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+@@ -197,7 +196,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+diff --git a/vs/vs2015/pdbdump/pdbdump.vcxproj b/vs/vs2015/pdbdump/pdbdump.vcxproj
+index cf2efc8..c20fb01 100755
+--- a/vs/vs2015/pdbdump/pdbdump.vcxproj
++++ b/vs/vs2015/pdbdump/pdbdump.vcxproj
+@@ -109,7 +108,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+@@ -135,7 +134,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+@@ -166,7 +165,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+@@ -197,7 +196,7 @@
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+     </Link>
+     <CustomBuildStep>
+-      <Command>python ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
++      <Command>py -3 ..\..\..\scripts\version.py ..\..\..\src\version.h.in ..\..\..\src\version.h --version-file ..\..\..\VERSION</Command>
+     </CustomBuildStep>
+     <CustomBuildStep>
+       <Outputs>..\..\..\src\version.h;%(Outputs)</Outputs>
+-- 
+2.39.1.windows.1
+


### PR DESCRIPTION
### Description

Adds the [ducible](https://github.com/jasonwhite/ducible) tool to windows deps.

Unfortunately ducible does not use CMake, but we don't need to link against it and just want the command line tools. This PR includes patches to make the included project work with VS 2022 and to fix a potential issue with invocation of the generic `python` command.

### Motivation and Context

For https://github.com/obsproject/obs-studio/pull/8220 to work at its best, we need to overwrite/remove certain parts from the PE metadata (e.g. timestamps). Ducible handles this and can be relatively easily be executed as part of CMake's custom post-build commands system.

Instead of relying on a third-party repository and code downloads from there, this compiles the tools on our CI and makes them part of obs-deps so they can be run as part of a CMake post-build command locally or on CI when creating reproducible builds.

### How Has This Been Tested?

Built locally.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
