### PR TITLE
deps.macos: Add VLC and Sparkle dependencies

### DIFF
--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -85,7 +85,7 @@ package() {
   if [[ ${PACKAGE_NAME} != 'qt'* ]] {
     log_status "Cleanup unnecessary files"
 
-    rm -rf lib/^(*.dylib|libajantv*|*.a|*.so*|*.lib|cmake)(N)
+    rm -rf lib/^(*.dylib|libajantv*|*.a|*.so*|*.lib|*.framework|*.dSYM|cmake)(N)
     rm -rf lib/(libpcre*|libpng*)(N)
     rm -rf bin/^(*.exe|*.dll|*.pdb|swig)(N)
 

--- a/deps.macos/90-sparkle.zsh
+++ b/deps.macos/90-sparkle.zsh
@@ -1,0 +1,30 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='Sparkle'
+local version='2.3.2'
+local url='https://github.com/sparkle-project/Sparkle/releases/download/2.3.2/Sparkle-2.3.2.tar.xz'
+local hash="${0:a:h}/checksums/Sparkle-2.3.2.tar.xz.sha256"
+
+## Build Steps
+setup() {
+  autoload -Uz dep_download extract mkcd
+
+  log_info "Setup (%F{3}${target}%f)"
+  log_info "Download ${url}"
+  dep_download ${url} ${hash}
+
+  if (( ! ${skips[(Ie)unpack]} )) {
+    log_info "Extract ${url##*/}"
+    mkcd ${dir}
+    extract ../${url##*/}
+  }
+}
+
+install() {
+  log_info "Install (%F{3}${target}%f)"
+
+  cd "${dir}"
+  cp -r  Sparkle.framework "${target_config[output_dir]}"/lib
+  cp -r  Symbols/Sparkle.framework.dSYM "${target_config[output_dir]}"/lib
+}

--- a/deps.macos/90-vlc.zsh
+++ b/deps.macos/90-vlc.zsh
@@ -1,0 +1,32 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='vlc'
+local version='3.0.8'
+local url='https://downloads.videolan.org/vlc/3.0.8/vlc-3.0.8.tar.xz'
+local hash="${0:a:h}/checksums/vlc-3.0.8.tar.xz.sha256"
+
+## Build Steps
+setup() {
+  log_info "Setup (%F{3}${target}%f)"
+  setup_dep ${url} ${hash}
+}
+
+build() {
+  autoload -Uz mkcd progress
+
+  log_info "Build (%F{3}${target}%f)"
+
+  cd "${dir}"
+
+  local -a version_strings=(${(s:.:)version})
+
+  sed -e "s/(@VERSION_MAJOR@)/(${version_strings[1]})/g" -e "s/(@VERSION_MINOR@)/(${version_strings[2]})/g" -e "s/(@VERSION_REVISION@)/(${version_strings[3]})/g" include/vlc/libvlc_version.h.in >! include/vlc/libvlc_version.h
+}
+
+install() {
+  log_info "Install (%F{3}${target}%f)"
+
+  cd "${dir}"
+  cp -r include/vlc "${target_config[output_dir]}"/include
+}

--- a/deps.macos/checksums/Sparkle-2.3.2.tar.xz.sha256
+++ b/deps.macos/checksums/Sparkle-2.3.2.tar.xz.sha256
@@ -1,0 +1,1 @@
+2b3fe6918ca20a83729aad34f8f693a678b714a17d33b5f13ca2d25edfa7eed3  Sparkle-2.3.2.tar.xz

--- a/deps.macos/checksums/vlc-3.0.8.tar.xz.sha256
+++ b/deps.macos/checksums/vlc-3.0.8.tar.xz.sha256
@@ -1,0 +1,1 @@
+e0149ef4a20a19b9ecd87309c2d27787ee3f47dfd47c6639644bc1f6fd95bdf6  vlc-3.0.8.tar.xz


### PR DESCRIPTION
### Description
Adds libVLC headers and Sparkle framework (+dSYM) to obs-deps.

### Motivation and Context
Reduces complexity for build system setup on macOS as obs-deps will contain almost every build-time dependency on macOS. Also limits possible availability issues of videolan's servers to the time of an obs-deps release instead of every time obs-studio is built.

### How Has This Been Tested?
Build obs-deps with both dependencies, checked Framework files and headers are put to the correct destinations.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
