### PR TITLE
deps.windows: Add VLC to Windows dependencies

### DIFF
--- a/deps.windows/90-vlc.ps1
+++ b/deps.windows/90-vlc.ps1
@@ -1,0 +1,54 @@
+param(
+    [string] $Name = 'vlc',
+    [string] $Version = '3.0.8',
+    [string] $Uri = 'https://cdn-fastly.obsproject.com/downloads/vlc.zip',
+    [string] $Hash = "${PSScriptRoot}/checksums/vlc.zip.sha256"
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $VersionString = [System.Version] $Version
+
+    (Get-Content -Path include/vlc/libvlc_version.h.in -Raw) `
+        -replace "@VERSION_MAJOR@", "$($VersionString.Major)" `
+        -replace "@VERSION_MINOR@", "$($VersionString.Minor)" `
+        -replace "@VERSION_REVISION@", "$($VersionString.Build)" `
+        | Out-File -Path include/vlc/libvlc_version.h -NoNewLine
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Params = @{
+        ErrorAction = "SilentlyContinue"
+        Path = @(
+            "$($ConfigData.OutputPath)/include"
+        )
+        ItemType = "Directory"
+        Force = $true
+    }
+
+    New-Item @Params *> $null
+
+    $Items = @(
+        @{
+            Path = "include/vlc"
+            Destination = "$($ConfigData.OutputPath)/include/"
+            Recurse = $true
+            Force = $true
+        }
+    )
+
+    $Items | ForEach-Object {
+        $Item = $_
+        Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
+        Copy-Item @Item
+    }
+}

--- a/deps.windows/checksums/vlc.zip.sha256
+++ b/deps.windows/checksums/vlc.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">91F589EF69FCE51645A3ECBB215B405C98DB7B891479474EC3B5ED3B63C25E4A</S>
+      <S N="Path">windows_32-bit_build_temp\vlc.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/utils.pwsh/Invoke-SafeWebRequest.ps1
+++ b/utils.pwsh/Invoke-SafeWebRequest.ps1
@@ -49,19 +49,16 @@ function Invoke-SafeWebRequest {
         if ( ( $CheckExisting ) -and ( Test-Path $OutFile ) ) {
             $NewHash = Get-FileHash -Path $OutFile -Algorithm $Algorithm
         } else {
-            $WebRequestParams = @{
-                UserAgent = "NativeHost"
-                Uri = $Uri
-                OutFile = $OutFile
-                UseBasicParsing = $true
-                ErrorAction = "Stop"
+            if ( $Headers.count -gt 0 ) {
+                $HeaderStrings = @()
+
+                $Headers.GetEnumerator() | ForEach-Object {
+                    $Header = $_
+                    $HeaderStrings += "-H `"$($Header.key): $($Header.Value)`""
+                }
             }
 
-            if ( $Headers.Count -gt 0 ) {
-                $WebRequestParams += @{Headers = $Headers}
-            }
-
-            Invoke-WebRequest @WebRequestParams
+            curl.exe -Lf $Uri -o $OutFile $($HeaderStrings -join " ")
 
             $NewHash = Get-FileHash -Path $OutFile -Algorithm $Algorithm
         }


### PR DESCRIPTION
### Description
Adds libVLC headers to obs-deps.

### Motivation and Context
Reduces complexity for build system setup on Windows as obs-deps will contain almost every build-time dependency. Also limits possible availability issues of videolan's servers to the time of an obs-deps release instead of every time obs-studio is built.

### How Has This Been Tested?
Build obs-deps with both dependencies, checked headers are put to the correct destinations.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
