### PR TITLE
CI: Reduce Qt package compression level when not tagging

### DIFF
--- a/.github/actions/package-windows-qt/action.yml
+++ b/.github/actions/package-windows-qt/action.yml
@@ -66,14 +66,16 @@ runs:
     - name: Create combined Qt archive
       shell: pwsh
       run: |
+        if ( '${{ github.event_name }}' -eq 'push' -and '${{ github.ref }}' -like '*refs/tags/*' ) { $CompressionLevel = '9' } else { $CompressionLevel = '5' }
         $FileName = "${{ steps.GetFileNames.outputs.fileName }}"
-        7z a "$FileName" .\qt\* -mx=9
+        7z a "$FileName" .\qt\* -mx="$CompressionLevel"
 
     - name: Create Release PDBs archive
       shell: pwsh
       run: |
+        if ( '${{ github.event_name }}' -eq 'push' -and '${{ github.ref }}' -like '*refs/tags/*' ) { $CompressionLevel = '9' } else { $CompressionLevel = '5' }
         $FileName = "${{ steps.GetFileNames.outputs.pdbFileName }}"
-        7z a "$FileName" .\rel_pdbs\* -mx=9
+        7z a "$FileName" .\rel_pdbs\* -mx="$CompressionLevel"
 
     - name: Publish Combined Qt Artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The Windows Qt packaging step takes about 10 minutes on CI. We only need the maximum compression level on releases, so let's try using the default compression level on other events to see if that speeds up those CI runs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want slightly faster Windows CI runs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
CI is the test. I want to compare the run time and artifact size.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
