### PR TITLE
deps.qt: Backport macOS accessibility keyboard crash fix

### DIFF
--- a/deps.qt/patches/Qt6/mac/0001-QTBUG-106369.patch
+++ b/deps.qt/patches/Qt6/mac/0001-QTBUG-106369.patch
@@ -1,0 +1,159 @@
+From 441993a9a2e6cb236667ff67e06f1673df06db0a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Fri, 10 Mar 2023 13:49:39 +0100
+Subject: [PATCH] macOS: Guard text input client from destroyed QCocoaWindow
+
+The text input system on macOS may in some cases hold references to our
+QNSView, even after we've destroyed the corresponding QCocoaWindow. This
+happens e.g. when using the Keyboard Viewer to input text into a dialog,
+and then closing the dialog.
+
+In this situation we get text input callbacks such as selectedRange,
+attributedSubstringForProposedRange, firstRectForCharacterRange, and
+need to account for the lack of a valid platform window.
+
+This happens even if NSTextInputContext.currentInputContext has been
+updated to the input context of the parent window, and even if we
+explicitly deactivate the old input context and return nil for the
+input context of the now QCocoaWindow-less QNSView.
+
+We can combine this situation with the handling of a missing focus
+object, so that each callback doesn't need explicit platform window
+checks.
+
+Fixes: QTBUG-106369
+Fixes: QTBUG-111183
+Fixes: QTBUG-105250
+Pick-to: 6.5 6.2 5.15
+Change-Id: I5bc1b9667376c87221fe5007db162224c022c09f
+Reviewed-by: Volker Hilsheimer <volker.hilsheimer@qt.io>
+---
+ a/qtbase/src/plugins/platforms/cocoa/qnsview.mm        |  1 +
+ b/qtbase/src/platforms/cocoa/qnsview_complextext.mm    | 36 ++++++++++++-------
+ 2 files changed, 24 insertions(+), 13 deletions(-)
+
+diff --git a/qtbase/src/plugins/platforms/cocoa/qnsview.mm b/src/plugins/platforms/cocoa/qnsview.mm
+index c574e2b7c8..f8c17e179d 100644
+--- a/qtbase/src/plugins/platforms/cocoa/qnsview.mm
++++ b/qtbase/src/plugins/platforms/cocoa/qnsview.mm
+@@ -83,6 +83,7 @@ @interface QNSView (Keys)
+ @end
+ 
+ @interface QNSView (ComplexText) <NSTextInputClient>
++@property (readonly) QObject* focusObject;
+ @end
+ 
+ @implementation QNSView {
+diff --git a/qtbase/src/plugins/platforms/cocoa/qnsview_complextext.mm b/src/plugins/platforms/cocoa/qnsview_complextext.mm
+index cdeb7154fe..3ccaf8269e 100644
+--- a/qtbase/src/plugins/platforms/cocoa/qnsview_complextext.mm
++++ b/qtbase/src/plugins/platforms/cocoa/qnsview_complextext.mm
+@@ -7,6 +7,17 @@ @implementation QNSView (ComplexText)
+ 
+ // ------------- Text insertion -------------
+ 
++- (QObject*)focusObject
++{
++    // The text input system may still hold a reference to our QNSView,
++    // even after QCocoaWindow has been destructed, delivering text input
++    // events to us, so we need to guard for this situation explicitly.
++    if (!m_platformWindow)
++        return nullptr;
++
++    return m_platformWindow->window()->focusObject();
++}
++
+ /*
+     Inserts the given text, potentially replacing existing text.
+ 
+@@ -52,8 +63,7 @@ - (void)insertText:(id)text replacementRange:(NSRange)replacementRange
+         }
+     }
+ 
+-    QObject *focusObject = m_platformWindow->window()->focusObject();
+-    if (queryInputMethod(focusObject)) {
++    if (queryInputMethod(self.focusObject)) {
+         QInputMethodEvent inputMethodEvent;
+ 
+         const bool isAttributedString = [text isKindOfClass:NSAttributedString.class];
+@@ -75,7 +85,7 @@ - (void)insertText:(id)text replacementRange:(NSRange)replacementRange
+             inputMethodEvent.setCommitString(commitString, replaceFrom, replaceLength);
+         }
+ 
+-        QCoreApplication::sendEvent(focusObject, &inputMethodEvent);
++        QCoreApplication::sendEvent(self.focusObject, &inputMethodEvent);
+     }
+ 
+     m_composingText.clear();
+@@ -86,6 +96,9 @@ - (void)insertNewline:(id)sender
+ {
+     Q_UNUSED(sender);
+ 
++    if (!m_platformWindow)
++        return;
++
+     // Depending on the input method, pressing enter may
+     // result in simply dismissing the input method editor,
+     // without confirming the composition. In other cases
+@@ -242,7 +255,7 @@ - (void)setMarkedText:(id)text selectedRange:(NSRange)selectedRange replacementR
+     // Update the composition, now that we've computed the replacement range
+     m_composingText = preeditString;
+ 
+-    if (QObject *focusObject = m_platformWindow->window()->focusObject()) {
++    if (QObject *focusObject = self.focusObject) {
+         m_composingFocusObject = focusObject;
+         if (queryInputMethod(focusObject)) {
+             QInputMethodEvent event(preeditString, preeditAttributes);
+@@ -284,8 +297,7 @@ This maps to the location and length of the current preedit (composited) string.
+ */
+ - (NSRange)markedRange
+ {
+-    QObject *focusObject = m_platformWindow->window()->focusObject();
+-    if (auto queryResult = queryInputMethod(focusObject, Qt::ImAbsolutePosition)) {
++    if (auto queryResult = queryInputMethod(self.focusObject, Qt::ImAbsolutePosition)) {
+         int absoluteCursorPosition = queryResult.value(Qt::ImAbsolutePosition).toInt();
+ 
+         // The cursor position as reflected by Qt::ImAbsolutePosition is not
+@@ -320,7 +332,7 @@ - (void)unmarkText
+         << "for focus object" << m_composingFocusObject;
+ 
+     if (!m_composingText.isEmpty()) {
+-        QObject *focusObject = m_platformWindow->window()->focusObject();
++        QObject *focusObject = self.focusObject;
+         if (queryInputMethod(focusObject)) {
+             QInputMethodEvent e;
+             e.setCommitString(m_composingText);
+@@ -393,8 +405,7 @@ - (void)doCommandBySelector:(SEL)selector
+ */
+ - (NSRange)selectedRange
+ {
+-    QObject *focusObject = m_platformWindow->window()->focusObject();
+-    if (auto queryResult = queryInputMethod(focusObject,
++    if (auto queryResult = queryInputMethod(self.focusObject,
+             Qt::ImCursorPosition | Qt::ImAbsolutePosition | Qt::ImAnchorPosition)) {
+ 
+         // Unfortunately the Qt::InputMethodQuery values are all relative
+@@ -441,8 +452,7 @@ - (NSRange)selectedRange
+ */
+ - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)range actualRange:(NSRangePointer)actualRange
+ {
+-    QObject *focusObject = m_platformWindow->window()->focusObject();
+-    if (auto queryResult = queryInputMethod(focusObject,
++    if (auto queryResult = queryInputMethod(self.focusObject,
+             Qt::ImAbsolutePosition | Qt::ImTextBeforeCursor | Qt::ImTextAfterCursor)) {
+         const int absoluteCursorPosition = queryResult.value(Qt::ImAbsolutePosition).toInt();
+         const QString textBeforeCursor = queryResult.value(Qt::ImTextBeforeCursor).toString();
+@@ -478,8 +488,8 @@ - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)
+     Q_UNUSED(range);
+     Q_UNUSED(actualRange);
+ 
+-    QWindow *window = m_platformWindow->window();
+-    if (queryInputMethod(window->focusObject())) {
++    QWindow *window = m_platformWindow ? m_platformWindow->window() : nullptr;
++    if (window && queryInputMethod(window->focusObject())) {
+         QRect cursorRect = qApp->inputMethod()->cursorRectangle().toRect();
+         cursorRect.moveBottomLeft(window->mapToGlobal(cursorRect.bottomLeft()));
+         return QCocoaScreen::mapToNative(cursorRect);
+-- 
+2.37.1 (Apple Git-137.1)
+

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -5,7 +5,10 @@ local name='qt6'
 local version=6.4.1
 local url='https://download.qt.io/official_releases/qt/6.4/6.4.1'
 local hash="${0:a:h}/checksums"
-local -a patches=()
+local -a patches=(
+  "macos ${0:a:h}/patches/Qt6/mac/0001-QTBUG-106369.patch \
+    f96ce8408b03e752708c606df10d6473aeed78843a6acb0a90c05f0a9fc913af"
+)
 
 local -a qt_components=(
   'qtbase'


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Backports qt/qtbase@441993a9 which will only be in Qt 6.5.1 and later.

*In theory* we could also add it to our Qt 5.15 builds but realistically we're never going to use those again.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, OBS is basically unusable with the accessibility keyboard enabled, as every time you type something in a dialog OBS will crash when closing the dialog.
This is very much sub-optimal.

The commit in Qt unfortunately made it neither into 6.4.3 (which will be the last 6.4 release) nor 6.5.0, both of which (at least the RC) are due to be released in the coming days, and is only in 6.5.1.
I think this is a fix worth including however.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested that with current obs-deps it still crashes.
Tested both with the Qt dev branch as well as a [CI build of this PR](https://github.com/gxalpha/obs-deps/actions/runs/4420528834) that the crash is gone.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
