### PR TITLE
deps.ffmpeg: Fix AOM target CPU arch

### DIFF
--- a/deps.ffmpeg/40-aom.zsh
+++ b/deps.ffmpeg/40-aom.zsh
@@ -55,7 +55,6 @@ config() {
   args=(
     ${cmake_flags}
     -DBUILD_SHARED_LIBS="${_onoff[(( shared_libs + 1 ))]}"
-    -DAOM_TARGET_CPU="${arch}"
     -DENABLE_DOCS=OFF
     -DENABLE_EXAMPLES=OFF
     -DENABLE_TESTDATA=OFF
@@ -65,7 +64,7 @@ config() {
   )
 
   case ${target} {
-    macos-arm64) args+=(-DCONFIG_RUNTIME_CPU_DETECT=0) ;;
+    macos-*) args+=(-DCONFIG_RUNTIME_CPU_DETECT=0 -DCMAKE_TOOLCHAIN_FILE="build/cmake/toolchains/${target_config[cmake_arch]}-macos.cmake") ;;
     windows-x*) args+=(-DCMAKE_TOOLCHAIN_FILE="build/cmake/toolchains/${target_config[cmake_arch]}-mingw-gcc.cmake")
   }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
AOM allows you to set the target CPU arch (AOM_TARGET_CPU) at configure time. If not specified, their CMake will attempt to autodetect this value based on CMAKE_SYSTEM_PROCESSOR. The value of AOM_TARGET_CPU is then used to enable various optimizations.

We used to not set a value for AOM_TARGET_CPU.[1] We started setting a value for it with the unified FFmpeg build. However, we set the value of "arch" based on the build target string (i.e., windows-x86 or windows-x64), which results in an "arch" of "x86" or "x64". AOM's CMake does expect the value "x64" as a possible value of AOM_TARGET_CPU, as it instead expects "x86_64".[2] However, it will not produce a configure error if given "x64" for the value of AOM_TARGET_CPU. It will accept this value, but then subsequent checks will rely on the value being "x86" or "x86_64" for things like using YASM or NASM.

AOM's CMake will correctly set this from the value of CMAKE_SYSTEM_PROCESSOR, which we already set for Windows builds, so let's just remove AOM_TARGET_CPU as a global override option, and instead also specify CMAKE_TOOLCHAIN_FILE for macOS builds.


References:
[1]: https://github.com/obsproject/obs-deps/blob/6366c22b731c31112449d1d323daafaf8e306e3c/CI/windows/build_libaom.sh#L28-L43 [2]: https://aomedia.googlesource.com/aom.git/+/refs/tags/v3.6.0/build/cmake/aom_configure.cmake#57
 *   https://cmake.org/cmake/help/v3.26/variable/CMAKE_SYSTEM_PROCESSOR.html
 *   https://aomedia.googlesource.com/aom.git/+/refs/tags/v3.4.0/build/cmake/aom_configure.cmake#53


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want optimizations when available.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've built AOM locally both in x86 and x86_64 (x64) configurations and built the whole FFmpeg dependency chain this way. You can see the change reflected in the build log:
```
--- aom_configure: Detected CPU: x86_64
```
where it used to say:
```
--- aom_configure: Detected CPU: x64
```

See also:
* https://github.com/obsproject/obs-deps/actions/runs/4448056886/jobs/7810352225#step:6:1286
* https://github.com/obsproject/obs-deps/actions/runs/4448056886/jobs/7810352547#step:6:2278

I have not yet tested the subsequent build in OBS, but I don't suspect anything will break. If something does, we can easily revert this.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
