### PR TITLE
deps.ffmpeg: Add OpenH264

### DIFF
--- a/deps.ffmpeg/40-openh264.zsh
+++ b/deps.ffmpeg/40-openh264.zsh
@@ -1,0 +1,136 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='openh264'
+local version='2.3.1'
+local url='https://github.com/cisco/openh264.git'
+local hash='0a48f4d2e9be2abb4fb01b4c3be83cf44ce91a6e'
+
+## Dependency Overrides
+local -i shared_libs=1
+
+## Build Steps
+setup() {
+  log_info "Setup (%F{3}${target}%f)"
+  setup_dep ${url} ${hash}
+}
+
+clean() {
+  cd "${dir}"
+
+  if [[ ${clean_build} -gt 0 && -f "build_${arch}/build.ninja" ]] {
+    log_info "Clean build directory (%F{3}${target}%f)"
+
+    rm -rf "build_${arch}"
+  }
+}
+
+config() {
+  autoload -Uz mkcd progress
+
+  local build_type
+
+  case ${config} {
+    Debug) build_type='debug' ;;
+    RelWithDebInfo) build_type='debugoptimized' ;;
+    Release) build_type='release' ;;
+    MinSizeRel) build_type='minsize' ;;
+  }
+
+  if (( shared_libs )) {
+    args+=(--default-library both)
+  } else {
+    args+=(--default-library static)
+  }
+
+  case "${target}" {
+    macos-universal)
+      autoload -Uz universal_config && universal_config
+      return
+      ;;
+    macos-*) args+=(--cross-file "cross_compile_${arch}.txt") ;;
+    windows-x*)
+      args+=(--cross-file "cross_mingw_${target_config[cmake_arch]}.txt")
+
+      autoload -Uz hide_dlls && hide_dlls
+      ;;
+  }
+
+  log_info "Config (%F{3}${target}%f)"
+  cd "${dir}"
+
+  args+=(
+    --buildtype "${build_type}"
+    --prefix "${target_config[output_dir]}"
+    -Dtests=false
+    -Dpkg_config_path="${target_config[output_dir]}/lib/pkgconfig"
+  )
+
+  log_debug "Meson configure options: ${args}"
+  meson setup "build_${arch}" ${args}
+}
+
+build() {
+  autoload -Uz mkcd progress
+
+  case ${target} {
+    macos-universal)
+      autoload -Uz universal_build && universal_build
+      return
+      ;;
+  }
+
+  log_info "Build (%F{3}${target}%f)"
+  cd "${dir}"
+
+  log_debug "Running meson compile -C build_${arch}"
+  meson compile -C "build_${arch}"
+}
+
+install() {
+  autoload -Uz progress
+
+  log_info "Install (%F{3}${target}%f)"
+
+  cd "${dir}"
+
+  meson install -C "build_${arch}"
+}
+
+fixup() {
+  cd "${dir}"
+
+  if (( shared_libs )) {
+    log_info "Fixup (%F{3}${target}%f)"
+    case ${target} {
+      macos*)
+        autoload -Uz fix_rpaths
+        fix_rpaths "${target_config[output_dir]}"/lib/libopenh264*.dylib(.)
+
+        strip_tool=strip
+        strip_files=("${target_config[output_dir]}"/lib/libopenh264*.dylib(.))
+        ;;
+      linux*)
+        strip_tool=strip
+        strip_files=("${target_config[output_dir]}"/lib/libopenh264.so*(.))
+        ;;
+      windows-x*)
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libopenh264*.dll(.)
+
+        strip_tool=${target_config[cross_prefix]}-w64-mingw32-strip
+        strip_files=("${target_config[output_dir]}"/bin/libopenh264*.dll(.))
+
+        autoload -Uz restore_dlls && restore_dlls
+        ;;
+    }
+
+    if [[ "${config}" == (Release|MinSizeRel) ]] {
+      local file
+      for file (${strip_files}(N)) {
+        ${strip_tool} -x "${file}"
+        log_status "Stripped ${file#"${target_config[output_dir]}"}"
+      }
+    }
+  }
+}

--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -192,6 +192,7 @@ config() {
     --extra-ldflags="${ff_ldflags}"
     --enable-version3
     --enable-gpl
+    --enable-libopenh264
     --enable-libx264
     --enable-libopus
     --enable-libvorbis


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds OpenH264 as a build dependency for FFmpeg.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This is being done to support https://github.com/obsproject/obs-studio/pull/8529, which adds support for using OpenH264 to encode H.264 video in OBS through FFmpeg.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
