### PR TITLE
deps.ffmpeg: Update FFmpeg to 3980415627

### DIFF
--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -4,7 +4,7 @@ autoload -Uz log_debug log_error log_info log_status log_output
 local name='FFmpeg'
 local version='6.0'
 local url='https://github.com/FFmpeg/FFmpeg.git'
-local hash='ea3d24bbe3c58b171e55fe2151fc7ffaca3ab3d2'
+local hash='3980415627a187d188dc25669cea6b12912eb178'
 local -a patches=(
   "* ${0:a:h}/patches/FFmpeg/0001-FFmpeg-6.0-OBS.patch \
     7fcb67d5e68a6ca3102c3a6aaba56750b22850552ccd8704c6636c174968ef56"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
FFmpeg n6.0 has a bug with NVENC that causes OBS to crash. It was fixed in the commit immediatley after the n6.0 tag. There is currently no n6.0.1 tag, so update to the latest release/6.0 commit so that OBS does not crash when using FFmpeg NVENC.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want OBS crashes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I haven't tested this. I am mostly hoping that `release/6.0` is stable enough to pull the latest commit until n6.0.1 comes out.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
