### PR TITLE
deps.windows: Update dependencies for CMake 3.0 upgrade

### DIFF
--- a/.github/actions/build-windows-deps/action.yml
+++ b/.github/actions/build-windows-deps/action.yml
@@ -1,67 +1,72 @@
-name: 'Build Windows Dependencies'
-description: 'Builds Windows dependencies for obs-deps with specified architecture, type, and build config'
+name: Build Windows Dependencies
+description: Builds Windows dependencies for obs-deps with specified architecture, type, and build config
 inputs:
   target:
-    description: 'Build target for dependencies'
+    description: Build target for dependencies
     required: true
   type:
-    description: 'Build type (shared or static libraries)'
+    description: Build type (shared or static libraries)
     required: false
-    default: 'static'
+    default: static
   config:
-    description: 'Build configuration'
+    description: Build configuration
     required: false
-    default: 'Release'
-  cacheRevision:
-    description: 'Cache revision number to force creation of new cache generation'
+    default: Release
+  workingDirectory:
+    description: Working directory for repository action
     required: false
-    default: '01'
+    default: ${{ github.workspace }}
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Environment Setup
-      id: deps-env-setup
+      id: env-setup
       shell: pwsh
       run: |
-        Get-Content .\deps.windows\*.ps1 > temp.txt
-        $DepsHash = ((Get-FileHash -Path temp.txt -Algorithm SHA256).Hash)
+        # Environment Setup
 
-        "hash=${DepsHash}" >> $env:GITHUB_OUTPUT
+        $Content = Get-Content ${{ inputs.workingDirectory }}/deps.windows/*.ps1
+
+        $Sha256Hasher = [System.Security.Cryptography.HashAlgorithm]::Create('sha256')
+        $ContentHash = $Sha256Hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Content))
+
+        "hash=$([System.BitConverter]::ToString($ContentHash).Replace('-','').SubString(0,9).ToLower())" >> $env:GITHUB_OUTPUT
 
     - name: Restore Windows Dependencies from Cache
       id: deps-cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: |
-          ${{ github.workspace }}/*_build_temp/*
-          !${{ github.workspace }}/*_build_temp/**/.git
-          !${{ github.workspace }}/*_build_temp/*.tar.gz
-          !${{ github.workspace }}/*_build_temp/*.tar.xz
-          !${{ github.workspace }}/*_build_temp/*.zip
-        key: ${{ inputs.target }}-deps-${{ inputs.type }}-${{ steps.deps-env-setup.outputs.hash }}-${{ inputs.cacheRevision }}
+          ${{ inputs.workingDirectory }}/*_build_temp/*
+          !${{ inputs.workingDirectory }}/*_build_temp/**/.git
+          !${{ inputs.workingDirectory }}/*_build_temp/*.tar.gz
+          !${{ inputs.workingDirectory }}/*_build_temp/*.tar.xz
+          !${{ inputs.workingDirectory }}/*_build_temp/*.zip
+        key: ${{ inputs.target }}-deps-${{ inputs.type }}-${{ inputs.config }}-${{ steps.env-setup.outputs.hash }}
 
     - name: Install Windows Dependencies
-      if: ${{ steps.deps-cache.outputs.cache-hit == 'true' }}
       shell: pwsh
       run: |
-        $Params = @{
-          SkipBuild = $true
-          SkipUnpack = $true
-          Target = '${{ inputs.target }}'
-          Configuration = '${{ inputs.config }}'
-        }
-        if ( '${{ inputs.type }}' -eq 'shared' ) { $Params += @{Shared = $true} }
+        # Install Windows Dependencies
 
-        ./Build-Dependencies.ps1 @Params
-
-    - name: Build and Install Windows Dependencies
-      if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-      shell: pwsh
-      run: |
         $Params = @{
           Target = '${{ inputs.target }}'
           Configuration = '${{ inputs.config }}'
+          Shared = $(if ( '${{ inputs.type }}' -eq 'shared' ) { $true } else { $false })
+          SkipBuild = $(if ( '${{ steps.deps-cache.outputs.cache-hit }}' -eq 'true' ) { $true } else { $false })
+          SkipUnpack = $(if ( '${{ steps.deps-cache.outputs.cache-hit }}' -eq 'true' ) { $true } else { $false })
         }
-        if ( '${{ inputs.type }}' -eq 'shared' ) { $Params += @{Shared = $true} }
 
         ./Build-Dependencies.ps1 @Params
+
+    - name: Save Windows Dependencies to Cache
+      uses: actions/cache/save@v3
+      if: github.event_name == 'schedule' || (github.event_name == 'push' && steps.deps-cache.outputs.cache-hit != 'true')
+      with:
+        path: |
+          ${{ inputs.workingDirectory }}/*_build_temp/*
+          !${{ inputs.workingDirectory }}/*_build_temp/**/.git
+          !${{ inputs.workingDirectory }}/*_build_temp/*.tar.gz
+          !${{ inputs.workingDirectory }}/*_build_temp/*.tar.xz
+          !${{ inputs.workingDirectory }}/*_build_temp/*.zip
+        key: ${{ inputs.target }}-deps-${{ inputs.type }}-${{ inputs.config }}-${{ steps.env-setup.outputs.hash }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -375,21 +375,20 @@ jobs:
           outputName: qt6-${{ matrix.target }}-${{ needs.pre-checks.outputs.shortHash }}
 
   windows-build:
-    name: 'Build Windows Dependencies'
+    name: Build Windows Dependencies
     runs-on: windows-2022
+    needs: pre-checks
     strategy:
       fail-fast: true
       matrix:
         target: [x64, x86]
         include:
           - target: x64
-            config: 'Release'
-            type: 'static'
+            config: Release
+            type: static
           - target: x86
-            config: 'Release'
-            type: 'static'
-    env:
-      CACHE_REVISION: '3'
+            config: Release
+            type: static
     defaults:
       run:
         shell: pwsh
@@ -400,41 +399,26 @@ jobs:
       - name: Setup Environment
         id: setup
         run: |
+          # Setup Environment
+
           $Target='${{ matrix.target }}'
-          $ArtifactName="deps-windows-${Target}-${{ github.sha }}"
+          $ArtifactName="deps-windows-${Target}-${{ needs.pre-checks.outputs.shortHash }}"
           $FileName="windows-deps-$(Get-Date -Format 'yyyy-MM-dd')-${Target}.zip"
 
           "artifactName=${ArtifactName}" >> $env:GITHUB_OUTPUT
           "artifactFileName=${FileName}" >> $env:GITHUB_OUTPUT
 
-      - name: 'Check for GitHub Labels'
-        id: seekingTesters
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          $LabelFound = try {
-            $Params = @{
-              Authentication = 'Bearer'
-              Token = (ConvertTo-SecureString '${{ secrets.GITHUB_TOKEN }}' -AsPlainText)
-              Uri = '${{ github.event.pull_request.url }}'
-              UseBasicParsing = $true
-            }
-
-            (Invoke-RestMethod @Params).labels.name.contains("Seeking Testers")
-          } catch {
-            $false
-          }
-
-          "found=$(([string]${LabelFound}).ToLower())" >> $env:GITHUB_OUTPUT
-
-      - name: Build ntv2 debug
+      - name: Build ntv2 Debug
+        if: matrix.target == 'x64'
         shell: pwsh
         run: |
+          # Build ntv2 Debug
+
           $Params = @{
             Target = '${{ matrix.target }}'
             Configuration = 'Debug'
             Dependencies = 'ntv2'
           }
-          if ( '${{ matrix.type }}' -eq 'shared' ) { $Params += @{Shared = $true} }
 
           ./Build-Dependencies.ps1 @Params
           Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
@@ -445,10 +429,9 @@ jobs:
           target: ${{ matrix.target }}
           type: ${{ matrix.type }}
           config: ${{ matrix.config }}
-          cacheRevision: ${{ env.CACHE_REVISION }}
 
       - name: Publish Build Artifacts
-        if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
+        if: github.event_name != 'pull_request' || fromJSON(needs.pre-checks.outputs.seekingTesters)
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.setup.outputs.artifactName }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -51,7 +51,7 @@ jobs:
             fi
           done <<< \
           "$(gh api repos/${GITHUB_REPOSITORY}/actions/caches \
-            --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")) | select(.key|test(".+-qt6-.+")) | {id, key} | join(";")')"
+            --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")) | select(.key|test(".+-(qt6|deps)-.+")) | select(.key|test(".+ffmpeg.+")|not) | {id, key} | join(";")')"
           echo '::endgroup::'
 
           echo '::group::Processing pull request cache entries'
@@ -72,6 +72,49 @@ jobs:
             "$(gh api 'repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100' \
               --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")|not) | {id, key, ref} | join(";")' &> /dev/null)"
           echo '::endgroup::'
+
+  windows-build:
+    name: Build Windows Dependencies
+    runs-on: windows-2022
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [x64, x86]
+        include:
+          - target: x64
+            config: Release
+            type: static
+          - target: x86
+            config: Release
+            type: static
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build ntv2 Debug
+        if: matrix.target == 'x64'
+        shell: pwsh
+        run: |
+          # Build ntv2 Debug
+
+          $Params = @{
+            Target = '${{ matrix.target }}'
+            Configuration = 'Debug'
+            Dependencies = 'ntv2'
+          }
+
+          ./Build-Dependencies.ps1 @Params
+          Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
+
+      - name: Build Windows Dependencies
+        uses: ./.github/actions/build-windows-deps
+        with:
+          target: ${{ matrix.target }}
+          type: ${{ matrix.type }}
+          config: ${{ matrix.config }}
 
   macos-qt6-build:
     name: Build Qt6 (macOS)

--- a/Build-Dependencies.ps1
+++ b/Build-Dependencies.ps1
@@ -11,7 +11,8 @@ param(
     [switch] $SkipAll,
     [switch] $SkipBuild,
     [switch] $SkipDeps,
-    [switch] $SkipUnpack
+    [switch] $SkipUnpack,
+    [switch] $VSPrerelease
 )
 
 $ErrorActionPreference = "Stop"

--- a/Build-Dependencies.ps1
+++ b/Build-Dependencies.ps1
@@ -62,7 +62,15 @@ function Run-Stages {
 
         . $Dependency
 
-        if ( ! ( $Targets.contains($Target) ) ) { continue }
+        if ( ! ( $Targets.contains($Target) ) ) {
+            $Stages | ForEach-Object {
+                Log-Debug "Removing function $_"
+                Remove-Item -ErrorAction 'SilentlyContinue' function:$_
+                $script:StageName = ''
+            }
+
+            return
+        }
 
         if ( $Version -eq '' ) { $Version = $Versions[$Target] }
         if ( $Uri -eq '' ) { $Uri = $Uris[$Target] }
@@ -133,6 +141,19 @@ function Package-Dependencies {
     )
 
     Remove-Item -ErrorAction 'SilentlyContinue' -Path $Items -Force -Recurse
+
+    $Params = @{
+        ErrorAction = "SilentlyContinue"
+        Path = @(
+            "share/obs-deps"
+        )
+        ItemType = "Directory"
+        Force = $true
+    }
+
+    New-Item @Params *> $null
+
+    "$(Get-Date -Format "yyyy-MM-dd")" > share/obs-deps/VERSION
 
     Log-Information "Package dependencies"
 

--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -86,7 +86,7 @@ package() {
     log_status "Cleanup unnecessary files"
 
     rm -rf lib/^(*.dylib|libajantv*|*.a|*.so*|*.lib|*.framework|*.dSYM|cmake)(N)
-    rm -rf lib/(libpcre*|libpng*)(N)
+    rm -rf lib/(libpcre*|libpng*|libz.*)(N)
     rm -rf bin/^(*.exe|*.dll|*.pdb|swig)(N)
 
     if [[ -f bin/swig ]] {

--- a/deps.windows/20-freetype.ps1
+++ b/deps.windows/20-freetype.ps1
@@ -24,12 +24,12 @@ function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(
         $CmakeOptions
-        "-DBUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])"
-        '-DFT_DISABLE_BROTLI=ON'
-        '-DFT_DISABLE_BZIP2=ON'
-        '-DFT_DISABLE_HARFBUZZ=ON'
-        '-DFT_DISABLE_PNG=ON'
-        '-DFT_DISABLE_ZLIB=ON'
+        "-DBUILD_SHARED_LIBS:BOOL=$($OnOff[$script:Shared.isPresent])"
+        '-DFT_DISABLE_BROTLI:BOOL=ON'
+        '-DFT_DISABLE_BZIP2:BOOL=ON'
+        '-DFT_DISABLE_HARFBUZZ:BOOL=ON'
+        '-DFT_DISABLE_PNG:BOOL=ON'
+        '-DFT_DISABLE_ZLIB:BOOL=ON'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/30-cmocka.ps1
+++ b/deps.windows/30-cmocka.ps1
@@ -35,9 +35,9 @@ function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(
         $CmakeOptions
-        "-DBUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])"
-        '-DBUILD_TESTING=OFF'
-        '-DWITH_EXAMPLES=OFF'
+        "-DBUILD_SHARED_LIBS:BOOL=$($OnOff[$script:Shared.isPresent])"
+        '-DBUILD_TESTING:BOOL=OFF'
+        '-DWITH_EXAMPLES:BOOL=OFF'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/30-curl.ps1
+++ b/deps.windows/30-curl.ps1
@@ -34,11 +34,11 @@ function Configure {
 
     $Options = @(
         $CmakeOptions
-        '-DBUILD_CURL_EXE=OFF'
-        '-DBUILD_TESTING=OFF'
-        '-DCURL_USE_LIBSSH2=OFF'
-        '-DCURL_USE_SCHANNEL=ON'
-        '-DCURL_ZLIB=OFF'
+        '-DBUILD_CURL_EXE:BOOL=OFF'
+        '-DBUILD_TESTING:BOOL=OFF'
+        '-DCURL_USE_LIBSSH2:BOOL=OFF'
+        '-DCURL_USE_SCHANNEL:BOOL=ON'
+        '-DCURL_ZLIB:BOOL=OFF'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/30-jansson.ps1
+++ b/deps.windows/30-jansson.ps1
@@ -24,10 +24,10 @@ function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(
         $CmakeOptions
-        '-DJANSSON_EXAMPLES=OFF'
-        '-DJANSSON_BUILD_DOCS=OFF'
-        "-DJANSSON_BUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])"
-        '-DJANSSON_WITHOUT_TESTS=ON'
+        '-DJANSSON_EXAMPLES:BOOL=OFF'
+        '-DJANSSON_BUILD_DOCS:BOOL=OFF'
+        "-DJANSSON_BUILD_SHARED_LIBS:BOOL=$($OnOff[$script:Shared.isPresent])"
+        '-DJANSSON_WITHOUT_TESTS:BOOL=ON'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/30-rnnoise.ps1
+++ b/deps.windows/30-rnnoise.ps1
@@ -25,8 +25,8 @@ function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(
         $CmakeOptions
-        "-DBUILD_SHARED_LIBS=$($OnOff[$script:Shared.isPresent])"
-        '-DRNNOISE_COMPILE_OPUS=ON'
+        "-DBUILD_SHARED_LIBS:BOOL=$($OnOff[$script:Shared.isPresent])"
+        '-DRNNOISE_COMPILE_OPUS:BOOL=ON'
     )
 
     Log-Debug "CMake configure options: ${Options}"

--- a/deps.windows/40-luajit.ps1
+++ b/deps.windows/40-luajit.ps1
@@ -33,7 +33,7 @@ function Install {
         Force = $true
     }
 
-    $null = New-Item @Params
+    New-Item @Params -ErrorAction SilentlyContinue > $null
 
     $Items = @(
         @{
@@ -41,8 +41,12 @@ function Install {
             Destination = "$($ConfigData.OutputPath)/include/luajit"
         }
         @{
-            Path = "src/lua51.dll", "src/lua51.lib"
+            Path = "src/lua51.dll"
             Destination = "$($ConfigData.OutputPath)/bin"
+        }
+        @{
+            Path = "src/lua51.lib"
+            Destination = "$($ConfigData.OutputPath)/lib"
         }
     )
 

--- a/deps.windows/50-pcre.ps1
+++ b/deps.windows/50-pcre.ps1
@@ -24,7 +24,7 @@ function Configure {
 
     $Options = @(
         $CmakeOptions
-        "-DBUILD_SHARED_LIBS=OFF"
+        "-DBUILD_SHARED_LIBS:BOOL=OFF"
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/50-swig.ps1
+++ b/deps.windows/50-swig.ps1
@@ -90,6 +90,14 @@ function Fixup {
     $Items = @(
         @{
             Path = "$($ConfigData.OutputPath)/swig/bin/swig.exe"
+            Destination = "$($ConfigData.OutputPath)/bin/swig.exe"
+        },
+        @{
+            Path = "$($ConfigData.OutputPath)/swig/share/swig/${Version}"
+            Destination = "$($ConfigData.OutputPath)/bin/Lib"
+        }
+        @{
+            Path = "$($ConfigData.OutputPath)/swig/bin/swig.exe"
             Destination = "$($ConfigData.OutputPath)/swig/swig.exe"
         },
         @{
@@ -101,7 +109,10 @@ function Fixup {
     $Items | ForEach-Object {
         $Item = $_
         Log-Status ('{0} => {1}' -f $Item.Path, $Item.Destination)
-        Move-Item @Item
+        if ( Test-Path $Item.Destination ) {
+            Remove-Item -Recurse -Force $Item.Destination
+        }
+        Copy-Item @Item -Recurse
     }
 
     Remove-Item "$($ConfigData.OutputPath)/swig/share" -Recurse -ErrorAction 'SilentlyContinue'

--- a/deps.windows/60-nlohmann-json.ps1
+++ b/deps.windows/60-nlohmann-json.ps1
@@ -24,7 +24,7 @@ function Configure {
 
     $Options = @(
         $CmakeOptions
-        '-DJSON_BuildTests=OFF'
+        '-DJSON_BuildTests:BOOL=OFF'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/60-ntv2.ps1
+++ b/deps.windows/60-ntv2.ps1
@@ -32,11 +32,11 @@ function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(
         $CmakeOptions
-        "-DAJA_BUILD_SHARED=$($OnOff[$Shared])"
-        '-DAJA_BUILD_OPENSOURCE=ON'
-        '-DAJA_BUILD_APPS=OFF'
-        '-DAJA_INSTALL_SOURCES=OFF'
-        '-DAJA_INSTALL_HEADERS=ON'
+        "-DAJA_BUILD_SHARED:BOOL=$($OnOff[$Shared])"
+        '-DAJA_BUILD_OPENSOURCE:BOOL=ON'
+        '-DAJA_BUILD_APPS:BOOL=OFF'
+        '-DAJA_INSTALL_SOURCES:BOOL=OFF'
+        '-DAJA_INSTALL_HEADERS:BOOL=ON'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/60-python.ps1
+++ b/deps.windows/60-python.ps1
@@ -10,30 +10,30 @@ param(
 )
 
 function Enable-PyEnv {
-    $Env:PYENV = "$(Get-Location | Convert-Path)\pyenv-win"
-    $Env:PYENV_ROOT = $Env:PYENV
-    $Env:PYENV_HOME = $Env:PYENV
+    $env:PYENV = "$(Get-Location | Convert-Path)\pyenv-win"
+    $env:PYENV_ROOT = $env:PYENV
+    $env:PYENV_HOME = $env:PYENV
 
-    $Env:OriginalPath = $Env:Path
+    $env:OriginalPath = $env:Path
 
-    $PathElements = ([Collections.Generic.HashSet[string]]::new([string[]]($Env:Path -split [System.IO.Path]::PathSeparator), [StringComparer]::OrdinalIgnoreCase))
+    $PathElements = ([Collections.Generic.HashSet[string]]::new([string[]]($env:Path -split [System.IO.Path]::PathSeparator), [StringComparer]::OrdinalIgnoreCase))
 
     $PyEnvPaths = @(
-        "${Env:PYENV}\bin"
-        "${Env:PYENV}\shims"
+        "${env:PYENV}\bin"
+        "${env:PYENV}\shims"
     )
-    $Env:Path = ($PyEnvPaths + $PathElements) -join [System.IO.Path]::PathSeparator
+    $env:Path = ($PyEnvPaths + $PathElements) -join [System.IO.Path]::PathSeparator
 
     $null = Invoke-External pyenv rehash
 }
 
 function Disable-PyEnv {
-    $Env:Path = $Env:OriginalPath
+    $env:Path = $Env:OriginalPath
 
-    Remove-Item Env:OriginalPath
-    Remove-Item Env:PYENV
-    Remove-Item Env:PYENV_ROOT
-    Remove-Item Env:PYENV_HOME
+    Remove-Item env:OriginalPath
+    Remove-Item env:PYENV
+    Remove-Item env:PYENV_ROOT
+    Remove-Item env:PYENV_HOME
 }
 
 function Setup {
@@ -105,6 +105,6 @@ function Install {
     $Items | ForEach-Object {
         $Item = $_
         Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
-        Copy-Item @Item
+        Copy-Item -Force @Item
     }
 }

--- a/deps.windows/60-websocketpp.ps1
+++ b/deps.windows/60-websocketpp.ps1
@@ -40,9 +40,9 @@ function Configure {
 
     $Options = @(
         $CmakeOptions
-        '-DENABLE_CPP11=ON'
-        '-DBUILD_EXAMPLES=OFF'
-        '-DBUILD_TESTS=OFF'
+        '-DENABLE_CPP11:BOOL=ON'
+        '-DBUILD_EXAMPLES:BOOL=OFF'
+        '-DBUILD_TESTS:BOOL=OFF'
     )
 
     Invoke-External cmake -S . -B "build_${Target}" @Options

--- a/deps.windows/60-zstd.ps1
+++ b/deps.windows/60-zstd.ps1
@@ -24,11 +24,11 @@ function Configure {
 
     $Options = @(
         $CmakeOptions
-        '-DZSTD_BUILD_PROGRAMS=OFF'
-        '-DZSTD_BUILD_TESTS=OFF'
-        '-DZSTD_BUILD_SHARED=OFF'
-        '-DZSTD_USE_STATIC_RUNTIME=ON'
-        '-DZSTD_LEGACY_SUPPORT=OFF'
+        '-DZSTD_BUILD_PROGRAMS:BOOL=OFF'
+        '-DZSTD_BUILD_TESTS:BOOL=OFF'
+        '-DZSTD_BUILD_SHARED:BOOL=OFF'
+        '-DZSTD_USE_STATIC_RUNTIME:BOOL=ON'
+        '-DZSTD_LEGACY_SUPPORT:BOOL=OFF'
     )
 
     Invoke-External cmake -S build/cmake -B "build_${Target}" @Options

--- a/utils.pwsh/Invoke-DevShell.ps1
+++ b/utils.pwsh/Invoke-DevShell.ps1
@@ -39,12 +39,12 @@ function Invoke-DevShell {
 @"
 `$ErrorActionPreference = 'Stop'
 
-Import-Module '$($VisualStudioData.InstallLocation)/Common7/Tools/Microsoft.VisualStudio.DevShell.dll'
+Import-Module '$($VisualStudioData.InstallationPath)/Common7/Tools/Microsoft.VisualStudio.DevShell.dll'
 
 `$_Params = @{
     StartInPath = '${BasePath}'
     DevCmdArguments = '-arch=${Target} -host_arch=${HostArchitecture}'
-    VsInstanceId = '$(($VisualStudioData.InstanceId -split ':')[2])'
+    VsInstanceId = '$($VisualStudioData.InstanceId)'
 }
 
 Enter-VsDevShell @_Params

--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -39,8 +39,8 @@ function Setup-BuildParameters {
     $VisualStudioData = Find-VisualStudio
 
     $VisualStudioId = "Visual Studio {0} {1}" -f @(
-        ([System.Version] $VisualStudioData.Version).Major
-        ([regex]::Match($VisualStudioData.Name, "\b\d{4}\b"))
+        $VisualStudioData.InstallationVersion.Major
+        ($VisualStudioData.DisplayName -split ' ')[-1]
     )
 
     $script:CmakeOptions = @(
@@ -77,29 +77,15 @@ function Find-VisualStudio {
             Find-VisualStudio
     #>
 
-    $VisualStudioData = Get-CimInstance MSFT_VSInstance
-
-    # Prefer VS versions in this order:
-    # 1. VS2022 Release (stable)
-    # 2. VS2022 Preview
-    # 3. VS2019 Release
-    [string[]]$SupportedVSVersions =
-        "VisualStudio.17.Release",
-        "VisualStudio.17.Preview",
-        "VisualStudio.16.Release"
-    $NumSupportedVSVersions = $SupportedVSVersions.length
-
-    if ( $VisualStudioData.GetType() -eq [object[]] ) {
-        for ( $i = 0; $i -lt $NumSupportedVSVersions; $i++ ) {
-            $VisualStudioDataTemp = ($VisualStudioData | Where-Object {$_.ChannelId -eq $SupportedVSVersions[$i]} | Sort-Object -Property Version)[0]
-            if ( $VisualStudioDataTemp ) {
-                break;
-            }
+    if ( $env:CI -eq $null ) {
+        if ( ( Get-InstalledModule VSSetup ) -eq $null ) {
+            Install-Module VSSetup -Scope CurrentUser
         }
-        $VisualStudioData = $VisualStudioDataTemp
     }
 
-    if ( ! ( $VisualStudioData ) -or ( $VisualStudioData.Version -lt 16 ) ) {
+    $VisualStudioData = Get-VSSetupInstance -Prerelease:$($script:VSPrerelease) | Select-VSSetupInstance -Version '[16.0,18.0)' -Latest
+
+    if ( $VisualStudioData -eq $null ) {
         $ErrorMessage = @(
             "A Visual Studio installation (2019 or newer) is required for this build script.",
             "The Visual Studio Community edition is available for free at https://visualstudio.microsoft.com/vs/community/.",


### PR DESCRIPTION
### Description

* Disables x86 builds for all dependencies not required by x86-only modules.
* Moves luajit and Swig files into their canonical locations expected by default CMake find rules.
* Uses VSSetup PowerShell module to find Visual Studio installations in a more portable manner (also supports ARM64 Windows hosts)
* Creates obs-deps `VERSION` file in Windows packages

### Motivation and Context
* Enables compatibility with CMake 3.0 upgrade for Windows
* Removes complexity for CMake finders in said upgrade (canonical paths are used)
* Enables use of a single x64 project for Windows

### How Has This Been Tested?
Tested builds on Windows 11

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
