### PR TITLE
deps.macos: Add Syphon Framework

### DIFF
--- a/deps.macos/90-syphon.zsh
+++ b/deps.macos/90-syphon.zsh
@@ -1,0 +1,40 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='syphon'
+local version='5.0'
+local url='https://github.com/Syphon/Syphon-Framework.git'
+local hash='fc4f4a2a71c0a8c7539a91093ad26c0c237602d6'
+
+## Build Steps
+setup() {
+  log_info "Setup (%F{3}${target}%f)"
+  setup_dep ${url} ${hash}
+}
+
+clean() {
+  cd "${dir}"
+
+  if [[ ${clean_build} -gt 0 && -d "build" ]] {
+    log_info "Clean build directory (%F{3}${target}%f)"
+
+    rm -rf "build"
+  }
+}
+
+build() {
+  autoload -Uz mkcd
+
+  log_info "Build (%F{3}${target}%f)"
+
+  cd "${dir}"
+  xcodebuild -project Syphon.xcodeproj -target Syphon -configuration "${config}"
+}
+
+install() {
+  log_info "Install (%F{3}${target}%f)"
+
+  cd "${dir}"
+  cp -Rp build/${config}/Syphon.framework "${target_config[output_dir]}"/lib
+  cp -Rp build/${config}/Syphon.framework.dSYM "${target_config[output_dir]}"/lib
+}

--- a/licenses/syphon/License.txt
+++ b/licenses/syphon/License.txt
@@ -1,0 +1,29 @@
+Syphon Framework License:
+
+Copyright 2010 bangnoise (Tom Butterworth) & vade (Anton Marini).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+* Neither the name of the Syphon Project nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
### Description
Adds syphon to obs-deps.
The workflow pulls their git repository (https://github.com/Syphon/Syphon-Framework) at the specified git commit (they don't seem to tag releases anymore).
Building builds the `Syphon` target of their distributed Xcode project, which generates a `Syphon.framework`.
Along with the debug symbols, this then gets copied to the `lib` directory.

### Motivation and Context
The OBS syphon plugin is currently using a 9(!) year old version of the syphon framework on a OBS contributors' fork because it had to be patched for IOSurfaces to be accessible (fun fact: Not counting the custom patches, it's exactly 9 years old to the day, see the [commit history](https://github.com/palana/Syphon-Framework/commits/master)).
Seeing that obs-deps wasn't a thing back then, it currently is a git submodule. This also means isn't built by Syphon's build system, with the source files instead just being stringed together by our obs-studio cmake.

Building syphon on obs-deps fixes these issues. It means that we can more easily update syphon (this PR of course brings in the latest version already), and utilizes their Xcode project to compile. It also reduces OBS' build time since the dependency doesn't need to be built with OBS.


### How Has This Been Tested?
Tested on my fork to correctly generate the `Syphon.framework` framework: https://github.com/gxalpha/obs-deps/actions/runs/4574746519
Built and ran their [sample server](https://github.com/Syphon/Simple) against this framework successfully (a non-recursive clone will avoid bringing in the submodule).
Had an OBS with the required cmake- and code-changes build and run against it. Successfully captured the sample servers' output.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
