### PR TITLE
deps.ffmpeg: Update FFmpeg and separate out patches

### DIFF
--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -4,7 +4,7 @@ autoload -Uz log_debug log_error log_info log_status log_output
 local name='FFmpeg'
 local version='6.0'
 local url='https://github.com/FFmpeg/FFmpeg.git'
-local hash='3980415627a187d188dc25669cea6b12912eb178'
+local hash='a6dc92968a325d331bb6dcf9b3b2248026cd1d6c'
 local -a patches=(
   "* ${0:a:h}/patches/FFmpeg/0001-flvdec-handle-unknown.patch \
     5a5185f54cbcf4672763cce687d1b6ddb662549b69637da826279ce4797f57ef"

--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -6,8 +6,10 @@ local version='6.0'
 local url='https://github.com/FFmpeg/FFmpeg.git'
 local hash='3980415627a187d188dc25669cea6b12912eb178'
 local -a patches=(
-  "* ${0:a:h}/patches/FFmpeg/0001-FFmpeg-6.0-OBS.patch \
-    7fcb67d5e68a6ca3102c3a6aaba56750b22850552ccd8704c6636c174968ef56"
+  "* ${0:a:h}/patches/FFmpeg/0001-flvdec-handle-unknown.patch \
+    5a5185f54cbcf4672763cce687d1b6ddb662549b69637da826279ce4797f57ef"
+  "* ${0:a:h}/patches/FFmpeg/0002-libaomenc-presets.patch \
+    d5f1410efb31fe31e8e905ec3f10ccb7841dd5594cb3591c3b205e77232fd183"
 )
 
 ## Build Steps

--- a/deps.ffmpeg/patches/FFmpeg/0001-flvdec-handle-unknown.patch
+++ b/deps.ffmpeg/patches/FFmpeg/0001-flvdec-handle-unknown.patch
@@ -1,0 +1,11 @@
+--- ./libavformat/flvdec.c	2021-10-24 22:47:07.000000000 +0200
++++ ./libavformat/flvdec.c	2021-11-08 13:13:47.000000000 +0100
+@@ -1077,7 +1077,7 @@
+             int type;
+             meta_pos = avio_tell(s->pb);
+             type = flv_read_metabody(s, next);
+-            if (type == 0 && dts == 0 || type < 0) {
++            if (type == 0 && dts == 0 || type < 0 || type == TYPE_UNKNOWN) {
+                 if (type < 0 && flv->validate_count &&
+                     flv->validate_index[0].pos     > next &&
+                     flv->validate_index[0].pos - 4 < next) {

--- a/deps.ffmpeg/patches/FFmpeg/0002-libaomenc-presets.patch
+++ b/deps.ffmpeg/patches/FFmpeg/0002-libaomenc-presets.patch
@@ -1,14 +1,3 @@
---- ./libavformat/flvdec.c	2021-10-24 22:47:07.000000000 +0200
-+++ ./libavformat/flvdec.c	2021-11-08 13:13:47.000000000 +0100
-@@ -1077,7 +1077,7 @@
-             int type;
-             meta_pos = avio_tell(s->pb);
-             type = flv_read_metabody(s, next);
--            if (type == 0 && dts == 0 || type < 0) {
-+            if (type == 0 && dts == 0 || type < 0 || type == TYPE_UNKNOWN) {
-                 if (type < 0 && flv->validate_count &&
-                     flv->validate_index[0].pos     > next &&
-                     flv->validate_index[0].pos - 4 < next) {
 --- ./libavcodec/libaomenc.c  2021-10-24 22:47:07.000000000 +0200
 +++ ./libavcodec/libaomenc.c  2021-11-08 13:15:54.000000000 +0100
 @@ -1337,7 +1337,7 @@


### PR DESCRIPTION
### Description

Adds a fix for NVENC DTS being wrong when b-frames are enabled. Also cleans up FFmpeg patches by splitting them up into separate files.

See https://github.com/obsproject/obs-studio/pull/8582

### Motivation and Context

Less pain.

### How Has This Been Tested?

@tt2468 confirmed it fixed DTS with NVENC on his machine.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
