### PR TITLE
utils.pwsh: Fix CMake error with VS Build Tools

### DIFF
--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -40,7 +40,7 @@ function Setup-BuildParameters {
 
     $VisualStudioId = "Visual Studio {0} {1}" -f @(
         ([System.Version] $VisualStudioData.Version).Major
-        ( $VisualStudioData.Name -split ' ')[3]
+        ([regex]::Match($VisualStudioData.Name, "\b\d{4}\b"))
     )
 
     $script:CmakeOptions = @(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This prevents an error where the Visual Studio generator extraction thing would work incorrectly if you had only the Build Tools installed.

### Motivation and Context
If you have the Visual Studio Build Tools installed, and not a full copy of Visual Studio, building cmake things would fail, as the output of `Find-VisualStudio` would be something along the lines of this:
```
Caption           : Visual Studio Build Tools 2022
Description       : The Visual Studio Build Tools allows you to build native and managed MSBuild-based applications
                    without requiring the Visual Studio IDE. There are options to install the Visual C++ compilers and
                    libraries, MFC, ATL, and C++/CLI support.
ElementName       : Visual Studio Build Tools 2022
InstanceID        : Microsoft:VisualStudio:e66d2ae7
IdentifyingNumber : e66d2ae7
Name              : Visual Studio Build Tools 2022
SKUNumber         :
Vendor            : Microsoft Corporation
Version           : 17.5.33516.290
WarrantyDuration  :
WarrantyStartDate :
ChannelId         : VisualStudio.17.Release
ChannelUri        : https://aka.ms/vs/17/release/channel
InstallDate       : 3/26/2023 2:20:23 PM
InstallLocation   : C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools
IsComplete        : True
IsLaunchable      : True
IsPrerelease      : False
LayoutPath        :
ProductId         : Microsoft.VisualStudio.Product.BuildTools
ProductLocation   : C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\LaunchDevCmd.bat
State             : 4294967295
PSComputerName    :
```

Which means `( $VisualStudioData.Name -split ' ')[3]` would return `Tools`, resulting in the build script trying to use "Visual Studio 17 Tools" as a cmake generator, which is invalid.

I replaced it with a small regex that just extracts a 4-digit number (a year) from the name instead.

### How Has This Been Tested?
By running `Build-Dependencies.ps1` locally

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
