### PR TITLE
deps.qt: Add missing obs-deps version file for Qt packages

### DIFF
--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -100,9 +100,9 @@ package() {
     if [[ -d cmake ]] rm -rf cmake
     if [[ -d man ]] rm -rf man
 
-    mkdir -p share/obs-deps
-    echo "${current_date}" >! share/obs-deps/VERSION
   }
+  mkdir -p share/obs-deps
+  echo "${current_date}" >! share/obs-deps/VERSION
 
   log_status "Create archive ${filename}"
   local -a _tarflags=()


### PR DESCRIPTION
### Description
Adds required `VERSION` file for Qt packages.

### Motivation and Context
When building libobs for plugins, prebuilt dependencies are already downloaded for the main plugin build. Current obs-studio doesn't correctly detect existing Qt dependencies as they're missing the required `VERSION` file.

### How Has This Been Tested?
Tested with manually added `VERSION` file in a plugin build.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
