### PR TITLE
CI: Add detection for single-arch static libraries

### DIFF
--- a/.github/actions/create-universal/action.yml
+++ b/.github/actions/create-universal/action.yml
@@ -65,7 +65,7 @@ runs:
         for file (**/*(.)) {
           magic=$(xxd -ps -l 4 ${file})
 
-          if [[ ${magic} == "cffaedfe" ]] fixups+=(${file})
+          if [[ ${magic} == "cffaedfe" || ${magic} == "213c6172" ]] fixups+=(${file})
         }
 
         for file (${fixups}) {


### PR DESCRIPTION
### Description
Adds detection of single-architecture static library to GitHub action responsible for generating universal architecture builds.

### Motivation and Context
Fixes compile issues for plugins which should default to universal binaries.

### How Has This Been Tested?
Tested on macOS 13.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
