### PR TITLE
Add Carla as dependency to macOS and Windows builds

### DIFF
--- a/deps.macos/80-carla.zsh
+++ b/deps.macos/80-carla.zsh
@@ -1,0 +1,78 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='carla'
+local version='2.6.0-alpha1'
+local url='https://github.com/falkTX/Carla.git'
+local hash='cb7f1a975790dda458481e88de0a29c433b706c9'
+
+## Build Steps
+setup() {
+  log_info "Setup (%F{3}${target}%f)"
+  setup_dep ${url} ${hash}
+}
+
+clean() {
+  cd "${dir}"
+
+  if [[ ${clean_build} -gt 0 && -d "build_${arch}" ]] {
+    log_info "Clean build directory (%F{3}${target}%f)"
+
+    rm -rf "build_${arch}"
+  }
+}
+
+config() {
+  autoload -Uz mkcd progress
+
+  log_info "Config (%F{3}${target}%f)"
+
+  args=(
+    ${cmake_flags}
+    -DCARLA_BUILD_FRAMEWORKS:BOOL=ON
+    -DCARLA_USE_JACK:BOOL=OFF
+    -DCARLA_USE_OSC:BOOL=OFF
+  )
+
+  cd "${dir}"
+  log_debug "CMake configure options: ${args}"
+  progress cmake -S cmake -B "build_${arch}" -G Ninja ${args}
+}
+
+build() {
+  autoload -Uz mkcd
+
+  log_info "Build (%F{3}${target}%f)"
+
+  cd "${dir}"
+  cmake --build "build_${arch}" --config "${config}"
+}
+
+install() {
+  autoload -Uz progress
+
+  log_info "Install (%F{3}${target}%f)"
+
+  args=(
+    --install "build_${arch}"
+    --config "${config}"
+  )
+
+  if [[ "${config}" =~ "Release|MinSizeRel" ]] args+=(--strip)
+
+  cd "${dir}"
+  progress cmake ${args}
+}
+
+fixup() {
+  cd "${dir}"
+
+  log_info "Fixup (%F{3}${target}%f)"
+  case ${target} {
+    macos*)
+      rm -r "${target_config[output_dir]}"/include
+      rm -r "${target_config[output_dir]}"/lib/carla-native-plugin.framework
+      rm -r "${target_config[output_dir]}"/lib/carla-standalone.framework
+      ;;
+  }
+}

--- a/deps.windows/60-carla.ps1
+++ b/deps.windows/60-carla.ps1
@@ -1,0 +1,75 @@
+param(
+    [string] $Name = 'carla',
+    [string] $Version = '2.6.0-alpha1',
+    [string] $Uri = 'https://github.com/falkTX/Carla.git',
+    [string] $Hash = 'cb7f1a975790dda458481e88de0a29c433b706c9'
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Clean {
+    Set-Location $Path
+
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        $CmakeOptions
+        '-DCARLA_USE_JACK:BOOL=OFF'
+        '-DCARLA_USE_OSC:BOOL=OFF'
+    )
+
+    Invoke-External cmake -S cmake -B "build_${Target}" @Options
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--install', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $Configuration -match "(Release|MinSizeRel)" ) {
+        $Options += '--strip'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Fixup {
+    Log-Information "Fixup (${Target})"
+    Set-Location $Path
+
+    Remove-Item -ErrorAction 'SilentlyContinue' "$($ConfigData.OutputPath)/bin/libcarla_native-plugin.dll"
+    Remove-Item -ErrorAction 'SilentlyContinue' "$($ConfigData.OutputPath)/bin/libcarla_standalone2.dll"
+
+    Remove-Item -ErrorAction 'SilentlyContinue' "$($ConfigData.OutputPath)/lib/libcarla_native-plugin.lib"
+    Remove-Item -ErrorAction 'SilentlyContinue' "$($ConfigData.OutputPath)/lib/libcarla_standalone2.lib"
+}


### PR DESCRIPTION
Here comes the obs-deps side for carla plugin host stuff. :)

### Description
Adds carla as a build dependency for macOS and Windows.
Windows builds use MSVC, and both through cmake.

### Motivation and Context
This is a requirement for https://github.com/obsproject/obs-studio/pull/8919
Instead of pulling in all of carla as a git submodule inside OBS, we build carla separately here (and only the necessary stuff, the PyQt Carla frontend is not neeeded for example)

### How Has This Been Tested?
I have tested that this works by making a release on my obs-deps fork https://github.com/falkTX/obs-deps/releases/tag/2023-06-01
Verified that the release artifacts contain the needed files.
Then tweaked my obs-studio private fork to make sure the builds were able to be used https://github.com/falkTX/obs-studio/actions/runs/5142961834/jobs/9257394909

Everything seems good as far as I can tell.

### Types of changes
Adds a single new dependency, built via https://github.com/falkTX/Carla/tree/main/cmake

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

### Extra notes

There is no tagged release on Carla side for the new 2.6.x series that brings support for MSVC and native VST3 hosting, as there is likely more stuff to fix.
Merging and updating the release version of obs-deps would still be extremely welcome, and that is a requirement for getting the full thing working on the OBS side.
After we verify that all works well within OBS, I can tag a release on Carla side.
