### PR TITLE
deps.qt: Add qtcharts

### DIFF
--- a/deps.qt/checksums/qtcharts-everywhere-src-6.8.3.tar.xz.sha256
+++ b/deps.qt/checksums/qtcharts-everywhere-src-6.8.3.tar.xz.sha256
@@ -1,0 +1,1 @@
+34aa5f5a48bb7481c9bd62172696831c73c2cef327aa6b871b1861693b3e0914  qtcharts-everywhere-src-6.8.3.tar.xz

--- a/deps.qt/checksums/qtcharts-everywhere-src-6.8.3.zip.sha256
+++ b/deps.qt/checksums/qtcharts-everywhere-src-6.8.3.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">aaf40d44eb54ea8b349f6e409f9c4ebabdcabcacce1f4045a01133b17f92117e</S>
+      <S N="Path">qtcharts-everywhere-src-6.8.3.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -8,6 +8,7 @@ param(
 
 $QtComponents = @(
     'qtbase'
+    'qtcharts'
     'qtimageformats'
     'qtshadertools'
     'qtmultimedia'
@@ -110,6 +111,7 @@ function Configure {
         '-DFEATURE_system_zlib:BOOL=OFF'
         '-DFEATURE_testlib:BOOL=OFF'
         '-DFEATURE_windeployqt:BOOL=OFF'
+        '-DINPUT_opengl:STRING=no'
         '-DINPUT_openssl:STRING=no'
         '-DQT_BUILD_BENCHMARKS:BOOL=OFF'
         '-DQT_BUILD_EXAMPLES:BOOL=OFF'

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -14,6 +14,7 @@ local -a patches=(
 
 local -a qt_components=(
   'qtbase'
+  'qtcharts'
   'qtimageformats'
   'qtshadertools'
   'qtmultimedia'
@@ -131,6 +132,7 @@ config() {
     -DFEATURE_system_zlib:BOOL=ON
     -DFEATURE_testlib:BOOL=OFF
     -DFEATURE_windeployqt:BOOL=OFF
+    -DINPUT_opengl:STRING=no
     -DINPUT_openssl:STRING=no
     -DQT_BUILD_BENCHMARKS:BOOL=OFF
     -DQT_BUILD_EXAMPLES:BOOL=OFF


### PR DESCRIPTION
### Description
This enables building of qtcharts (as well as qtopengl, qtopenglwidgets) on which it depends.

### Motivation and Context
This is a companion to other PRs in obs-studio enabling stats charts for SRT [1] & maybe regular stats.

[1] https://github.com/obsproject/obs-studio/pull/9027

### How Has This Been Tested?
Builds locally on windows and passes CI on my fork.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
