### PR TITLE
deps.windows: Add VPL

### DIFF
--- a/deps.windows/70-vpl.ps1
+++ b/deps.windows/70-vpl.ps1
@@ -1,0 +1,95 @@
+param(
+    [string] $Name = 'vpl',
+    [string] $Version = 'v2023.3.0',
+    [string] $Uri = 'https://github.com/oneapi-src/oneVPL.git',
+    [string] $Hash = 'e12ace9761bb52786409e830f619916b86e87fc5',
+    [switch] $ForceStatic = $true
+)
+
+function Setup {
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Clean {
+    Set-Location $Path
+
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    if ( $ForceStatic -and $script:Shared ) {
+        $Shared = $false
+    } else {
+        $Shared = $script:Shared.isPresent
+    }
+
+    $OnOff = @('OFF', 'ON')
+    $Options = @(
+        $CmakeOptions
+        '-DBUILD_DISPATCHER_ONLY:BOOL=ON'
+        '-DBUILD_EXAMPLES:BOOL=OFF'
+        '-DBUILD_DISPATCHER_ONEVPL_EXPERIMENTAL:BOOL=OFF'
+        "-DBUILD_SHARED_LIBS:BOOL=$($OnOff[$Shared])"
+    )
+
+    Invoke-External cmake -S . -B "build_${Target}" @Options
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Params = @{
+        ErrorAction = "SilentlyContinue"
+        Path = @(
+            "$($ConfigData.OutputPath)/lib"
+            "$($ConfigData.OutputPath)/include"
+        )
+        ItemType = "Directory"
+        Force = $true
+    }
+	
+    New-Item @Params *> $null
+
+    $Items = @(
+        @{
+            Path = "api/vpl"
+            Destination = "$($ConfigData.OutputPath)/include"
+            Recurse = $true
+            ErrorAction = 'SilentlyContinue'
+        }
+        @{
+            Path = "build_${Target}/$Configuration/vpl.lib"
+            Destination = "$($ConfigData.OutputPath)/lib"
+            ErrorAction = 'SilentlyContinue'
+        }
+    )
+	
+    $Items | ForEach-Object {
+        $Item = $_
+        Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
+        Copy-Item @Item
+    }
+}

--- a/licenses/vpl/LICENSE.txt
+++ b/licenses/vpl/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Adds vpl v2023.3.0 (latest) headers for obs-qsv11.
Linked with PR: https://github.com/obsproject/obs-studio/pull/9142
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Updates Intel MSDK to Intel VPL API to support future Intel hardware. Removes the MSDK files from the obs-studio repo with deprecated MSDK functions and links the VPL headers to obs-qsv11.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Testing is described in the linked obs-studio PR 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x ] My code is not on the master branch.
- [x ] The code has been tested.
- [x ] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.
