### PR TITLE
Remove non-essential Windows x86 deps builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -150,12 +150,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target: [x64, x86]
+        target: [x64]
         include:
           - target: x64
-            config: Release
-            type: static
-          - target: x86
             config: Release
             type: static
     defaults:
@@ -502,6 +499,7 @@ jobs:
           Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
 
       - name: Build qrcodegencpp Debug
+        if: matrix.target == 'x64'
         shell: pwsh
         run: |
           # Build qrcodegencpp Debug
@@ -536,7 +534,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target: [x64, x86]
+        target: [x64]
         config: [RelWithDebInfo, Debug]
 
     steps:
@@ -572,7 +570,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target: [x64, x86]
+        target: [x64]
     needs: [pre-checks, windows-qt6-build]
     steps:
       - name: Checkout

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -139,12 +139,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target: [x64, x86]
+        target: [x64]
         include:
           - target: x64
-            config: Release
-            type: static
-          - target: x86
             config: Release
             type: static
     defaults:
@@ -271,6 +268,7 @@ jobs:
           Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
 
       - name: Build qrcodegencpp Debug
+        if: matrix.target == 'x64'
         shell: pwsh
         run: |
           # Build qrcodegencpp Debug
@@ -343,7 +341,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target: [x64, x86]
+        target: [x64]
         config: [RelWithDebInfo, Debug]
 
     steps:

--- a/Build-Dependencies.ps1
+++ b/Build-Dependencies.ps1
@@ -133,11 +133,15 @@ function Package-Dependencies {
         dependencies {
             Get-ChildItem ./bin/*.lib | Move-Item -Destination ./lib
             Get-ChildItem ./bin -Exclude 'lua51.dll','libcurl.dll','swig.exe','Lib' | Remove-Item
-            Get-ChildItem ./cmake/pcre2*,./lib/pcre2* | Remove-Item
-            Remove-Item -Recurse ./lib/pkgconfig
-            Remove-Item -Recurse ./man
-            Get-ChildItem ./share -Exclude 'cmake' | Remove-Item -Recurse
-            Get-ChildItem ./share/cmake -Exclude 'nlohmann_json*' | Remove-Item -Recurse
+
+            if ( $script:Target -ne 'x86' ) {
+                Get-ChildItem ./cmake/pcre2*,./lib/pcre2* | Remove-Item
+                Remove-Item -Recurse ./lib/pkgconfig
+                Remove-Item -Recurse ./man
+                Get-ChildItem ./share -Exclude 'cmake' | Remove-Item -Recurse
+                Get-ChildItem ./share/cmake -Exclude 'nlohmann_json*' | Remove-Item -Recurse
+            }
+
             $ArchiveFileName = "windows-deps-${CurrentDate}-${Target}.zip"
         }
         qt {

--- a/deps.ffmpeg/10-zlib.ps1
+++ b/deps.ffmpeg/10-zlib.ps1
@@ -8,7 +8,8 @@ param(
             PatchFile = "${PSScriptRoot}/patches/zlib/0001-fix-unistd-detection.patch"
             HashSum = "2114ff9ebfc79765019353b06915a09f4dc4802ce722d2df6e640a59666dd875"
         }
-    )
+    ),
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/20-libpng.ps1
+++ b/deps.ffmpeg/20-libpng.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'libpng',
     [string] $Version = '1.6.43',
     [string] $Uri = 'https://sourceforge.net/projects/libpng/files/libpng16/1.6.43/lpng1643.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/lpng1643.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/lpng1643.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/20-opus.ps1
+++ b/deps.ffmpeg/20-opus.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'opus',
     [string] $Version = '1.5.2',
     [string] $Uri = 'https://github.com/xiph/opus.git',
-    [string] $Hash = "ddbe48383984d56acd9e1ab6a090c54ca6b735a6"
+    [string] $Hash = "ddbe48383984d56acd9e1ab6a090c54ca6b735a6",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/30-libogg.ps1
+++ b/deps.ffmpeg/30-libogg.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'libogg',
     [string] $Version = '1.3.5',
     [string] $Uri = 'https://github.com/xiph/ogg/releases/download/v1.3.5/libogg-1.3.5.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/libogg-1.3.5.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/libogg-1.3.5.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/30-libvorbis.ps1
+++ b/deps.ffmpeg/30-libvorbis.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'libvorbis',
     [string] $Version = '1.3.7',
     [string] $Uri = 'https://github.com/xiph/vorbis.git',
-    [string] $Hash = "84c023699cdf023a32fa4ded32019f194afcdad0"
+    [string] $Hash = "84c023699cdf023a32fa4ded32019f194afcdad0",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/30-libvpx.ps1
+++ b/deps.ffmpeg/30-libvpx.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'libvpx',
     [string] $Version = '1.14.0',
     [string] $Uri = 'https://github.com/webmproject/libvpx/archive/refs/tags/v1.14.0.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/v1.14.0.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/v1.14.0.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/40-x264.ps1
+++ b/deps.ffmpeg/40-x264.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = 'r3106',
     [string] $Uri = 'https://github.com/mirror/x264.git',
     [string] $Hash = 'eaa68fad9e5d201d42fde51665f2d137ae96baf0',
+    [array] $Targets = @('x64'),
     [switch] $ForceShared = $true
 )
 

--- a/deps.ffmpeg/50-libtheora.ps1
+++ b/deps.ffmpeg/50-libtheora.ps1
@@ -8,7 +8,8 @@ param(
             PatchFile = "${PSScriptRoot}/patches/libtheora/0001-add-windows-cmake.patch"
             HashSum = "9F7554581AABC81F360D040E95C1CBF935E9CD80019526B1A6951A1179524D50"
         }
-    )
+    ),
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/60-lame.ps1
+++ b/deps.ffmpeg/60-lame.ps1
@@ -8,7 +8,8 @@ param(
             PatchFile = "${PSScriptRoot}/patches/lame/0001-fix-nmake-64-bit-builds.patch"
             HashSum = "0772e07d3d0c484d281e3bfdb4f93e81adf303623fe57d955b98196795725f39"
         }
-    )
+    ),
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/60-mbedtls.ps1
+++ b/deps.ffmpeg/60-mbedtls.ps1
@@ -9,7 +9,8 @@ param(
             PatchFile = "${PSScriptRoot}/patches/mbedtls/0001-enable-dtls-srtp-support-windows.patch"
             HashSum = "38dbaff859242c5a4f8196a08e35f0251d2966b22e1d9547ecaaea2aec4aae1b"
         }
-    )
+    ),
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/60-srt.ps1
+++ b/deps.ffmpeg/60-srt.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = '1.5.2',
     [string] $Uri = 'https://github.com/Haivision/srt/archive/refs/tags/v1.5.2.zip',
     [string] $Hash = "${PSScriptRoot}/checksums/v1.5.2.zip.sha256",
+    [array] $Targets = @('x64'),
     [switch] $ForceShared = $true
 )
 

--- a/deps.ffmpeg/70-libdatachannel.ps1
+++ b/deps.ffmpeg/70-libdatachannel.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = 'v0.21.0',
     [string] $Uri = 'https://github.com/paullouisageneau/libdatachannel.git',
     [string] $Hash = '9d5c46b8f506943727104d766e5dad0693c5a223',
+    [array] $Targets = @('x64'),
     [switch] $ForceShared = $true
 )
 

--- a/deps.ffmpeg/70-librist.ps1
+++ b/deps.ffmpeg/70-librist.ps1
@@ -9,6 +9,7 @@ param(
             HashSum = "804B845BC66ED180B6C2F962ECF29D55190AA92248FE25F4478C68AE2A91DFFC"
         }
     ),
+    [array] $Targets = @('x64'),
     [switch] $ForceShared = $true
 )
 

--- a/deps.ffmpeg/70-nv-codec.ps1
+++ b/deps.ffmpeg/70-nv-codec.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'nv-codec-headers',
     [string] $Version = '12.2.72.0',
     [string] $Uri = 'https://github.com/FFmpeg/nv-codec-headers.git',
-    [string] $Hash = 'c69278340ab1d5559c7d7bf0edf615dc33ddbba7'
+    [string] $Hash = 'c69278340ab1d5559c7d7bf0edf615dc33ddbba7',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/80-amf.ps1
+++ b/deps.ffmpeg/80-amf.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'amf',
     [string] $Version = '1.4.33',
     [string] $Uri = 'https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git',
-    [string] $Hash = 'e8c7cd7c10d4e05c1913aa8dfd2be9f9dbdb03d6'
+    [string] $Hash = 'e8c7cd7c10d4e05c1913aa8dfd2be9f9dbdb03d6',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.ffmpeg/99-ffmpeg.ps1
+++ b/deps.ffmpeg/99-ffmpeg.ps1
@@ -12,7 +12,8 @@ param(
             PatchFile = "${PSScriptRoot}/patches/FFmpeg/0002-libaomenc-presets-Windows.patch"
             HashSum = "cec898b957fc289512094fc2c4e6a61d6872f716e4a643fb970c599a453a33f4"
         }
-    )
+    ),
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -3,7 +3,7 @@ param(
     [string] $Version = '6.6.3',
     [string] $Uri = 'https://download.qt.io/official_releases/qt/6.6/6.6.3',
     [string] $Hash = "${PSScriptRoot}/checksums",
-    [array] $Targets = @('x64', 'x86')
+    [array] $Targets = @('x64')
 )
 
 $QtComponents = @(
@@ -124,7 +124,6 @@ function Configure {
 
     $CMakeTarget = @{
         x64 = 'x64'
-        x86 = 'Win32'
     }
 
     $Options = ($Options -join ' ') -replace '-G Visual Studio \d+ \d+','-G Ninja' -replace "-A $($CMakeTarget[$Target])",''
@@ -208,7 +207,6 @@ function Qt-Add-Submodules {
 
     $CMakeTarget = @{
         x64 = 'x64'
-        x86 = 'Win32'
     }
 
     $QtComponents | Where-Object { $_ -ne 'qtbase' } | ForEach-Object {

--- a/deps.windows/20-freetype.ps1
+++ b/deps.windows/20-freetype.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'freetype',
     [string] $Version = '2.13.2',
     [string] $Uri = 'https://github.com/freetype/freetype.git',
-    [string] $Hash = '920c5502cc3ddda88f6c7d85ee834ac611bb11cc'
+    [string] $Hash = '920c5502cc3ddda88f6c7d85ee834ac611bb11cc',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/30-cmocka.ps1
+++ b/deps.windows/30-cmocka.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'cmocka',
     [string] $Version = '1.1.7',
     [string] $Uri = 'https://git.cryptomilk.org/projects/cmocka.git',
-    [string] $Hash = 'a01cc69ee9536f90e57c61a198f2d1944d3d4313'
+    [string] $Hash = 'a01cc69ee9536f90e57c61a198f2d1944d3d4313',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/30-curl.ps1
+++ b/deps.windows/30-curl.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'curl',
     [string] $Version = '8.7.1',
     [string] $Uri = 'https://github.com/curl/curl.git',
-    [string] $Hash = 'de7b3e89218467159a7af72d58cea8425946e97d'
+    [string] $Hash = 'de7b3e89218467159a7af72d58cea8425946e97d',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/30-jansson.ps1
+++ b/deps.windows/30-jansson.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'jansson',
     [string] $Version = '2.14',
     [string] $Uri = 'https://github.com/akheron/jansson.git',
-    [string] $Hash = '684e18c927e89615c2d501737e90018f4930d6c5'
+    [string] $Hash = '684e18c927e89615c2d501737e90018f4930d6c5',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/30-rnnoise.ps1
+++ b/deps.windows/30-rnnoise.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'rnnoise',
     [string] $Version = '2020-07-28',
     [string] $Uri = 'https://github.com/xiph/rnnoise.git',
-    [string] $Hash = '2938bcf94a2fe3f850df542f5de3996905059c97'
+    [string] $Hash = '2938bcf94a2fe3f850df542f5de3996905059c97',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/30-speexdsp.ps1
+++ b/deps.windows/30-speexdsp.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = '1.2.1',
     [string] $Uri = 'https://github.com/xiph/speexdsp.git',
     [string] $Hash = '1b28a0f61bc31162979e1f26f3981fc3637095c8',
+    [array] $Targets = @('x64'),
     [array] $Patches = @(
         @{
             PatchFile = "${PSScriptRoot}/patches/speexdsp/0001-Add-CMakeLists.patch"

--- a/deps.windows/40-luajit.ps1
+++ b/deps.windows/40-luajit.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'luajit',
     [string] $Version = '2.1',
     [string] $Uri = 'https://github.com/luajit/luajit.git',
-    [string] $Hash = '5790d253972c9d78a0c2aece527eda5b134bbbf7'
+    [string] $Hash = '5790d253972c9d78a0c2aece527eda5b134bbbf7',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/50-bison-bin.ps1
+++ b/deps.windows/50-bison-bin.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'bison',
     [string] $Version = '2.4.1',
     [string] $Uri = 'http://downloads.sourceforge.net/gnuwin32/bison-2.4.1-bin.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/bison-2.4.1-bin.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/bison-2.4.1-bin.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/50-bison-dep.ps1
+++ b/deps.windows/50-bison-dep.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'bison',
     [string] $Version = '2.4.1',
     [string] $Uri = 'http://downloads.sourceforge.net/gnuwin32/bison-2.4.1-dep.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/bison-2.4.1-dep.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/bison-2.4.1-dep.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/50-pcre.ps1
+++ b/deps.windows/50-pcre.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'pcre',
     [string] $Version = '10.40',
     [string] $Uri = 'https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.40/pcre2-10.40.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/pcre2-10.40.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/pcre2-10.40.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/50-swig.ps1
+++ b/deps.windows/50-swig.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = '4.1.0',
     [string] $Uri = 'https://github.com/swig/swig.git',
     [string] $Hash = "4dd285fad736c014224ef2ad25b85e17f3dce1f9",
+    [array] $Targets = @('x64'),
     [array] $Patches = @(
         @{
             PatchFile = "${PSScriptRoot}/patches/swig/0001-add-Python-3-stable-abi.patch"

--- a/deps.windows/60-asio.ps1
+++ b/deps.windows/60-asio.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'asio',
     [string] $Version = '1.30.2',
     [string] $Uri = 'https://github.com/chriskohlhoff/asio.git',
-    [string] $Hash = "12e0ce9e0500bf0f247dbd1ae894272656456079"
+    [string] $Hash = "12e0ce9e0500bf0f247dbd1ae894272656456079",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/60-libajantv2.ps1
+++ b/deps.windows/60-libajantv2.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = '17.0.1',
     [string] $Uri = 'https://github.com/aja-video/libajantv2.git',
     [string] $Hash = 'b6acce6b135c3d9ae7a2bce966180b159ced619f',
+    [array] $Targets = @('x64'),
     [switch] $ForceStatic = $true
 )
 

--- a/deps.windows/60-nlohmann-json.ps1
+++ b/deps.windows/60-nlohmann-json.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'nlohmann-json',
     [string] $Version = '3.11.3',
     [string] $Uri = 'https://github.com/nlohmann/json.git',
-    [string] $Hash = '9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03'
+    [string] $Hash = '9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/60-python.ps1
+++ b/deps.windows/60-python.ps1
@@ -3,8 +3,8 @@ param(
     [string] $Version = '3.1.1',
     [string] $Uri = 'https://github.com/pyenv-win/pyenv-win.git',
     [string] $Hash = '754a6ca877f66aaa2bd4485a29411267d0705273',
+    [array] $Targets = @('x64'),
     [hashtable] $PythonVersion = @{
-         x86 = '3.8.10-win32'
          x64 = '3.8.10'
     }
 )

--- a/deps.windows/60-qrcodegencpp.ps1
+++ b/deps.windows/60-qrcodegencpp.ps1
@@ -4,7 +4,8 @@ param(
     [string] $Uri = 'https://github.com/nayuki/QR-Code-generator.git',
     [string] $Hash = '720f62bddb7226106071d4728c292cb1df519ceb',
     [string] $UriCMake = 'https://github.com/EasyCoding/qrcodegen-cmake.git',
-    [string] $HashCMake = 'ea5835f7dca5bcf31dc795b1ac61bdc1f15940a7'
+    [string] $HashCMake = 'ea5835f7dca5bcf31dc795b1ac61bdc1f15940a7',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/60-simde.ps1
+++ b/deps.windows/60-simde.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'simde',
     [string] $Version = '0.8.2',
     [string] $Uri = 'https://github.com/simd-everywhere/simde.git',
-    [string] $Hash = '71fd833d9666141edcd1d3c109a80e228303d8d7'
+    [string] $Hash = '71fd833d9666141edcd1d3c109a80e228303d8d7',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/60-uthash.ps1
+++ b/deps.windows/60-uthash.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'uthash',
     [string] $Version = '2.3.0',
     [string] $Uri = 'https://github.com/troydhanson/uthash.git',
-    [string] $Hash = "e493aa90a2833b4655927598f169c31cfcdf7861"
+    [string] $Hash = "e493aa90a2833b4655927598f169c31cfcdf7861",
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/60-websocketpp.ps1
+++ b/deps.windows/60-websocketpp.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = '0.8.2',
     [string] $Uri = 'https://github.com/zaphoyd/websocketpp.git',
     [string] $Hash = '56123c87598f8b1dd471be83ca841ceae07f95ba',
+    [array] $Targets = @('x64'),
     [array] $Patches = @(
         @{
             PatchFile = "${PSScriptRoot}/patches/websocketpp/0001-update-minimum-cmake.patch"

--- a/deps.windows/60-zstd.ps1
+++ b/deps.windows/60-zstd.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'zstd',
     [string] $Version = 'v1.5.6',
     [string] $Uri = 'https://github.com/facebook/zstd.git',
-    [string] $Hash = '794ea1b0afca0f020f4e57b6732332231fb23c70'
+    [string] $Hash = '794ea1b0afca0f020f4e57b6732332231fb23c70',
+    [array] $Targets = @('x64')
 )
 
 function Setup {

--- a/deps.windows/70-vpl.ps1
+++ b/deps.windows/70-vpl.ps1
@@ -3,6 +3,7 @@ param(
     [string] $Version = 'v2.12.0',
     [string] $Uri = 'https://github.com/intel/libvpl.git',
     [string] $Hash = '0c13c410095764799afea0cf645bd896378579b8',
+    [array] $Targets = @('x64'),
     [switch] $ForceStatic = $true
 )
 

--- a/deps.windows/80-wil.ps1
+++ b/deps.windows/80-wil.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'wil',
     [string] $Version = 'v1.0.240122.1',
     [string] $Uri = 'https://github.com/microsoft/wil.git',
-    [string] $Hash = '5c6a7ba43e79edd71dcd1ce4c2d21b0610183c86', 
+    [string] $Hash = '5c6a7ba43e79edd71dcd1ce4c2d21b0610183c86',
+    [array] $Targets = @('x64'),
     [switch] $ForceStatic = $true
 )
 

--- a/deps.windows/90-vlc.ps1
+++ b/deps.windows/90-vlc.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Name = 'vlc',
     [string] $Version = '3.0.8',
     [string] $Uri = 'https://cdn-fastly.obsproject.com/downloads/vlc.zip',
-    [string] $Hash = "${PSScriptRoot}/checksums/vlc.zip.sha256"
+    [string] $Hash = "${PSScriptRoot}/checksums/vlc.zip.sha256",
+    [array] $Targets = @('x64')
 )
 
 function Setup {


### PR DESCRIPTION
### Description
Removes x86 slices of most Windows dependencies, with the exception of Detours and Vulkan, which are both needed for capture plugins.

### Motivation and Context
Deprecate all traces of standalone x86 OBS Studio versions.

### How Has This Been Tested?
Tested on Windows 11 VM.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
