### PR TITLE
CI: Update FFmpeg build jobs to use macOS 13-based runners

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,12 +62,12 @@ jobs:
         target: [macos-arm64, macos-x86_64, linux-x86_64, windows-x64, windows-x86]
         include:
           - target: macos-arm64
-            os: 'macos-12'
+            os: 'macos-13'
             config: 'Release'
             type: 'static'
             revision: 9
           - target: macos-x86_64
-            os: 'macos-12'
+            os: 'macos-13'
             config: 'Release'
             type: 'static'
             revision: 9
@@ -174,7 +174,7 @@ jobs:
 
   ffmpeg-package-universal:
     name: 'Build FFmpeg (Universal)'
-    runs-on: macos-12
+    runs-on: macos-13
     needs: [ffmpeg-build]
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
Updates FFmpeg build jobs to use macOS 13-based runners.

### Motivation and Context
macOS 13-based runners have more recent hardware than macOS 12-based runners and allow us to cut down on compilation time and also target more recent macOS versions moving forward.

### How Has This Been Tested?
As this changes CI workflows, test will be conducted by running the pull request workflow.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
