### PR TITLE
Update Windows build script to use explicit package names

### DIFF
--- a/.github/actions/build-qt/action.yaml
+++ b/.github/actions/build-qt/action.yaml
@@ -87,6 +87,7 @@ runs:
         # Build and Install Windows Qt
 
         $Params = @{
+          PackageName = 'qt'
           Target = '${{ inputs.target }}'
           Configuration = '${{ inputs.config }}'
           Shared = $true


### PR DESCRIPTION
### Description
Updates the Windows build script to explicitly identify dependency "package names" (instead of inferring them implicitly).

### Motivation and Context
Allows checking for package name globally and adopt different code paths for each package.

Prerequisite for https://github.com/obsproject/obs-deps/pull/186 as caches generated by nightly runs are incompatible with that codebase otherwise.

This change adds new parameter `PackageName` to the build script which selects the kind of dependency package to build:

* `dependencies` (the default)
* `qt`
* `ffmpeg` (added later in https://github.com/obsproject/obs-deps/pull/186)

When the parameter is omitted, default Windows dependencies are built. If Qt is to be built `-PackageName qt` needs to be provided instead.

### How Has This Been Tested?
Needs to be tested on CI and later with #186 after merging and rebasing.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
