### PR TITLE
CI: Fix unnecessary cache save attempt for Ccache contents

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -286,7 +286,7 @@ jobs:
           path: ${{ github.workspace }}/${{ matrix.target }}/${{ steps.setup.outputs.dsymArtifactFileName }}
 
       - name: Save Compilation Cache
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.ccache-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           path: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
### Description
Adds condition to check for unsuccessful cache restoration to cache saving step in macOS dependency build job.

### Motivation and Context
Compilation cache needs to be saved only if no successful restoration took place.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
