### PR TITLE
deps.windows: Add VPL debug library

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -469,6 +469,21 @@ jobs:
           ./Build-Dependencies.ps1 @Params
           Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
 
+      - name: Build VPL Debug
+        if: matrix.target == 'x64'
+        shell: pwsh
+        run: |
+          # Build VPL Debug
+
+          $Params = @{
+            Target = '${{ matrix.target }}'
+            Configuration = 'Debug'
+            Dependencies = 'vpl'
+          }
+
+          ./Build-Dependencies.ps1 @Params
+          Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
+
       - name: Build Windows Dependencies
         uses: ./.github/actions/build-deps
         with:

--- a/deps.windows/70-vpl.ps1
+++ b/deps.windows/70-vpl.ps1
@@ -70,7 +70,7 @@ function Install {
         ItemType = "Directory"
         Force = $true
     }
-	
+
     New-Item @Params *> $null
 
     $Items = @(
@@ -85,8 +85,13 @@ function Install {
             Destination = "$($ConfigData.OutputPath)/lib"
             ErrorAction = 'SilentlyContinue'
         }
+        @{
+            Path = "build_${Target}/$Configuration/vpld.lib"
+            Destination = "$($ConfigData.OutputPath)/lib"
+            ErrorAction = 'SilentlyContinue'
+        }
     )
-	
+
     $Items | ForEach-Object {
         $Item = $_
         Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
deps.windows: Install VPL Debug library if present

Also clean up some stray whitespace.

CI: Add VPL Debug build

Similar to AJA's NTV2 library, it seems that VPL requires a separate Debug library to be able to build OBS Studio in Debug with VPL. Use the same technique that we used for NTV2 for VPL.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to be able to build OBS Studio in Debug with QSV+VPL enabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11 by building the VPL dependency in Debug and then building OBS Studio in Debug with a VPL enabled branch.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
