### PR TITLE
Clean up old PowerShell code

### DIFF
--- a/Build-Dependencies.ps1
+++ b/Build-Dependencies.ps1
@@ -22,8 +22,8 @@ if ( $DebugPreference -eq "Continue" ) {
     $InformationPreference = "Continue"
 }
 
-if ( $PSVersionTable.PSVersion -lt '7.0.0' ) {
-    Write-Warning 'The obs-deps PowerShell build script requires PowerShell Core 7. Install or upgrade your PowerShell version: https://aka.ms/pscore6'
+if ( $PSVersionTable.PSVersion -lt '7.2.0' ) {
+    Write-Warning 'The obs-deps PowerShell build script requires PowerShell Core 7.2+. Install or upgrade your PowerShell version: https://aka.ms/pscore6'
     exit 0
 }
 

--- a/utils.pwsh/Invoke-DevShell.ps1
+++ b/utils.pwsh/Invoke-DevShell.ps1
@@ -62,11 +62,7 @@ if ( ! ( `$? ) ) {
     $_EAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
 
-    if ($PSVersionTable.PSEdition -eq "Core") {
-        $PowerShellCommand = "pwsh"
-    } else {
-        $PowerShellCommand = "powershell"
-    }
+    $PowerShellCommand = "pwsh"
 
     & $PowerShellCommand -Command $DevShellCommand
 

--- a/utils.pwsh/Invoke-SafeWebRequest.ps1
+++ b/utils.pwsh/Invoke-SafeWebRequest.ps1
@@ -27,11 +27,6 @@ function Invoke-SafeWebRequest {
         . $PSScriptRoot/Logger.ps1
     }
 
-    if ( $Resume -and $PSVersionTable.PSVersion -lt "6.1.0") {
-        Log-Warning "-Resume only available on PowerShell 6.1.0 or later, disabling"
-        $Resume = $false
-    }
-
     if ( ! ( Test-Path $HashFile ) ) {
         throw "Provided hash file ${HashFile} not found."
     }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove code branches that handled versions of PowerShell older than PowerShell 7.0 (such as PowerShell 5.x and 6.x, or Desktop vs. Core). Increase the minimum required PowerShell version from 7.0 to 7.2 since 7.0 is no longer supported.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
PowerShell 7.2 is the currently supported LTS version of PowerShell and is available on all GitHub Actions runner images. Let's shed a tiny bit of code that we don't need anymore.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
