### PR TITLE
deps.ffmpeg: Add missing fixup step for libdatachannel

### DIFF
--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -73,7 +73,7 @@ config() {
     -DGEN_FILES=OFF
   )
 
-  if [[ ${config} == Release ]] args+=(-DCMAKE_C_FLAGS="${c_flags} -std=c17 -g")
+  if [[ ${config} == Release ]] args+=(-DCMAKE_C_FLAGS="-std=c17 -g")
 
   log_info "Config (%F{3}${target}%f)"
   cd "${dir}"

--- a/deps.ffmpeg/70-libdatachannel.zsh
+++ b/deps.ffmpeg/70-libdatachannel.zsh
@@ -82,5 +82,50 @@ install() {
 }
 
 fixup() {
-}
+  cd ${dir}
 
+  log_info "Fixup (%F{3}${target}%f)"
+
+  local strip_tool
+  local -a strip_files
+
+  case ${target} {
+    macos*)
+      if (( shared_libs )) {
+        local -a dylib_files=(${target_config[output_dir]}/lib/libdatachannel*.dylib(.))
+
+        autoload -Uz fix_rpaths && fix_rpaths ${dylib_files}
+
+        if [[ ${config} == Release ]] dsymutil ${dylib_files}
+
+        strip_tool=strip
+        strip_files=(${dylib_files})
+      } else {
+        rm -rf -- ${target_config[output_dir]}/lib/libdatachannel*.(dylib|dSYM)(N)
+      }
+      ;;
+    linux*)
+      if (( shared_libs )) {
+        strip_tool=strip
+        strip_files=(${target_config[output_dir]}/lib/libdatachannel.so*(.))
+      } else {
+        rm -rf -- ${target_config[output_dir]}/lib/libdatachannel.so*(N)
+      }
+      ;;
+    windows-x*)
+      if (( shared_libs )) {
+        autoload -Uz create_importlibs
+        create_importlibs ${target_config[output_dir]}/bin/libdatachannel*.dll(.)
+
+        strip_tool=${target_config[cross_prefix]}-w64-mingw32-strip
+        strip_files=(${target_config[output_dir]}/bin/libdatachannel*.dll(.))
+      } else {
+        rm -rf -- ${target_config[output_dir]}/bin/libdatachannel*.dll(N)
+      }
+
+      autoload -Uz restore_dlls && restore_dlls
+      ;;
+  }
+
+  if (( #strip_files )) && [[ ${config} == (Release|MinSizeRel) ]] ${strip_tool} -x ${strip_files}
+}


### PR DESCRIPTION
### Description
Adds missing fixup step for `libdatachannel`.

### Motivation and Context
Every dynamic library shipped with OBS Studio needs to properly stripped, its debug information converted into a dSYM file and also its versioned filename removed from the library ID.

Also fixes a build issue with its dependency mbedtls when using Release configuration.

### How Has This Been Tested?
Tested with local builds of `libdatachannel`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
