### PR TITLE
CI: Enable qrcodegencpp Debug build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -484,6 +484,20 @@ jobs:
           ./Build-Dependencies.ps1 @Params
           Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
 
+      - name: Build qrcodegencpp Debug
+        shell: pwsh
+        run: |
+          # Build qrcodegencpp Debug
+
+          $Params = @{
+            Target = '${{ matrix.target }}'
+            Configuration = 'Debug'
+            Dependencies = 'qrcodegencpp'
+          }
+
+          ./Build-Dependencies.ps1 @Params
+          Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
+
       - name: Build Windows Dependencies
         uses: ./.github/actions/build-deps
         with:

--- a/deps.windows/60-qrcodegencpp.ps1
+++ b/deps.windows/60-qrcodegencpp.ps1
@@ -52,6 +52,7 @@ function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(
         $CmakeOptions
+        '-DCMAKE_DEBUG_POSTFIX:STRING=d'
         "-DBUILD_SHARED_LIBS:BOOL=$($OnOff[$script:Shared.isPresent])"
     )
 
@@ -99,6 +100,7 @@ function Fixup {
         @{ FullPath = "$($ConfigData.OutputPath)/lib/cmake/qrcodegen" }
         @{ FullPath = "$($ConfigData.OutputPath)/lib/pkgconfig/qrcodegen.pc" }
         @{ FullPath = "$($ConfigData.OutputPath)/lib/qrcodegen.*" }
+        @{ FullPath = "$($ConfigData.OutputPath)/lib/qrcodegend.*" }
         @{ FullPath = "$($ConfigData.OutputPath)/bin/qrcodegen.*" }
     )
 


### PR DESCRIPTION
### Description
Enables Debug builds of qrcodegencpp dependency

### Motivation and Context
Enables Debug builds without errors on obs-studio

### How Has This Been Tested?
Built the dependency with the following command and manually copied the generated files to obs-studio/.deps/.../ folder.
```
$Params = @{
>>     Target = 'x64'
>>     Configuration = 'Debug'
>>     Dependencies = 'qrcodegencpp'
>>   }
.\Build-Dependencies.ps1 @Params
```
Checked the WebSocket was enabled once again on Debug builds.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
