### PR TITLE
deps.qt: Fix library naming for macOS debug builds

### DIFF
--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -98,7 +98,8 @@ config() {
     fi
   }
 
-  if (( shared_libs)) && [[ ${config} == Release ]] common_cmake_flags+=(-DFEATURE_separate_debug_info:BOOL=ON -DQT_FEATURE_force_debug_info:BOOL=ON)
+  if (( shared_libs )) && [[ ${config} == Release ]] common_cmake_flags+=(-DFEATURE_separate_debug_info:BOOL=ON -DQT_FEATURE_force_debug_info:BOOL=ON)
+  if (( shared_libs )) && [[ ${config} == Debug ]] common_cmake_flags+=(-DCMAKE_PLATFORM_NO_VERSIONED_SONAME:BOOL=ON)
 
   args=(
     ${common_cmake_flags}
@@ -199,7 +200,8 @@ qt_add_submodules() {
     fi
   }
 
-  if (( shared_libs)) && [[ ${config} == Release ]] common_cmake_flags+=(-DFEATURE_separate_debug_info:BOOL=ON)
+  if (( shared_libs )) && [[ ${config} == Release ]] common_cmake_flags+=(-DFEATURE_separate_debug_info:BOOL=ON)
+  if (( shared_libs )) && [[ ${config} == Debug ]] common_cmake_flags+=(-DCMAKE_PLATFORM_NO_VERSIONED_SONAME:BOOL=ON)
 
   for component (${qt_components[2,-1]}) {
     if ! (( ${skips[(Ie)all]} + ${skips[(Ie)build]} )) {

--- a/utils.zsh/functions/fix_rpaths
+++ b/utils.zsh/functions/fix_rpaths
@@ -17,7 +17,7 @@ for lib ($@) {
 
   if otool -l ${lib} | grep LC_RPATH > /dev/null; then
     log_debug "Remove existing rpath entry"
-    install_name_tool -delete_rpath ${lib:A:h} ${lib}
+    install_name_tool -delete_rpath ${lib:A:h} ${lib} 2>/dev/null || true
   fi
 
   lib_basename=${lib:t}


### PR DESCRIPTION
### Description
Fixes the output file names and library IDs of Qt debug builds on macOS by forcing the use of unversioned `SONAME`s.

### Motivation and Context
The Xcode bundle generation requires libraries generated by CMake to not use versioned SONAMEs (as Linux does), which Qt does by default.

Disabling this behaviour generates unversioned dynamic libraries and makes them compatible with `obs-studio`'s build system.

With this change, a local Qt debug build can be copied over downloaded `obs-deps` and will be picked up whenever the project itself is built in Debug configuration.

### How Has This Been Tested?
Tested with Debug builds on macOS 13.5.2 and current Xcode.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
