### PR TITLE
deps.ffmpeg: Fix local universal architecture builds of aom for macOS

### DIFF
--- a/deps.ffmpeg/40-aom.zsh
+++ b/deps.ffmpeg/40-aom.zsh
@@ -50,6 +50,11 @@ patch() {
 config() {
   autoload -Uz mkcd progress
 
+  if [[ ${target} == macos-universal ]] {
+      autoload -Uz universal_config && universal_config
+      return
+  }
+
   local _onoff=(OFF ON)
 
   args=(
@@ -76,6 +81,11 @@ config() {
 
 build() {
   autoload -Uz mkcd progress
+
+  if [[ ${target} == macos-universal ]] {
+      autoload -Uz universal_build && universal_build
+      return
+  }
 
   log_info "Build (%F{3}${target}%f)"
 
@@ -104,6 +114,13 @@ install() {
   if (( _loglevel > 1 )) args+=(--verbose)
 
   cd ${dir}
+
+  if [[ ${target} == macos-universal ]] {
+    pushd build_universal
+    sed -i -E -e 's/build_x86_64/build_universal/g' cmake_install.cmake
+    popd
+  }
+
   progress cmake ${args}
 }
 
@@ -148,7 +165,6 @@ fixup() {
         rm -rf ${target_config[output_dir]}/bin/libaom*.dll(N)
       }
       ;;
-    }
   }
 
   if (( #strip_files )) && [[ ${config} == (Release|MinSizeRel) ]] ${strip_tool} -x ${strip_files}

--- a/utils.zsh/functions/universal_build
+++ b/utils.zsh/functions/universal_build
@@ -9,6 +9,7 @@ for arch (x86_64 arm64) {
     typeset -g -a cxx_flags=(${cxx_flags//universal/${arch}})
     typeset -g -a ld_flags=(${ld_flags//universal/${arch}})
     typeset -g -a as_flags=(${as_flags//universal/${arch}})
+    typeset -g -A target_config=(${(kv)target_config//x86_64;arm64/${arch}})
     build
   )
   if (( $? )) exit 2

--- a/utils.zsh/functions/universal_config
+++ b/utils.zsh/functions/universal_config
@@ -18,6 +18,8 @@ for arch (x86_64 arm64) {
     typeset -g -a cxx_flags=(${cxx_flags//universal/${arch}})
     typeset -g -a ld_flags=(${ld_flags//universal/${arch}})
     typeset -g -a as_flags=(${as_flags//universal/${arch}})
+    typeset -g -A target_config=(${(kv)target_config//x86_64;arm64/${arch}})
+    typeset -g -a cmake_flags=(${cmake_flags//x86_64;arm64/${arch}})
     config
   )
   if (( $? )) exit 2


### PR DESCRIPTION
### Description
Fixes universal builds of `aom` on macOS by extending the functionality available for non-CMake-based projects to also override CMake variables with architecture-specific identifiers.

### Motivation and Context
`aom` requires architecture-specific toolchain files to be built, but universal builds usually only require passing both modern Apple architectures to CMake to have the compiler create universal binaries by default.

Because of architecture-specific optimisations this is not possible for `aom`, so for local builds the architectures need to be built separately and then combined for the final installation.

### How Has This Been Tested?
Tested locally by building `aom` as static and shared libraries and checking the available architectures in the installed library files.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
