### PR TITLE
deps.ffmpeg: Fix libdatachannel packaging for macOS

### DIFF
--- a/deps.ffmpeg/70-libdatachannel.zsh
+++ b/deps.ffmpeg/70-libdatachannel.zsh
@@ -98,6 +98,10 @@ fixup() {
 
         if [[ ${config} == Release ]] dsymutil ${dylib_files}
 
+        for dylib_file (${dylib_files}) {
+          sed -i '' -E -e "s/${dylib_file:t}/libdatachannel.dylib/g" ${target_config[output_dir]}/lib/cmake/LibDataChannel/LibDataChannelTargets-${(L)config}.cmake
+        }
+
         strip_tool=strip
         strip_files=(${dylib_files})
       } else {


### PR DESCRIPTION
### Description
Fix malformed `SONAME` and library name in CMake package file generated for `libdatachannel`.

Fixes current issue with `obs-webrtc` failing to load in OBS Studio on macOS because the dependency library cannot be resolved by the dynamic library loader.

### Motivation and Context
Libraries should not be symlinked or versioned on macOS, so we need to fix not only the generated binaries but also the CMake package files to reflect this.

### How Has This Been Tested?
Built `libdatachannel` locally with the fixes applied and replaced corresponding contents in downloaded `obs-deps`, then built and ran OBS Studio to check if `obs-webrtc` is correctly loaded.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
