### PR TITLE
deps.qt: Fix C++17 compile issues with AppleClang 15

### DIFF
--- a/deps.qt/patches/0001-fix-macos-c++17-include.patch
+++ b/deps.qt/patches/0001-fix-macos-c++17-include.patch
@@ -1,0 +1,64 @@
+--- a/qtbase/src/corelib/tools/qduplicatetracker_p.h   2023-09-24 01:57:15
++++ b/qtbase/src/corelib/tools/qduplicatetracker_p.h   2023-09-24 01:57:32
+@@ -16,37 +16,12 @@
+ 
+ #include <private/qglobal_p.h>
+ 
+-#if __has_include(<memory_resource>)
+-#  include <unordered_set>
+-#  include <memory_resource>
+-#  include <qhash.h> // for the hashing helpers
+-#else
+ #  include <qset.h>
+-#endif
+ 
+ QT_BEGIN_NAMESPACE
+ 
+ template <typename T, size_t Prealloc = 32>
+ class QDuplicateTracker {
+-#ifdef __cpp_lib_memory_resource
+-    template <typename HT>
+-    struct QHasher {
+-        size_t storedSeed = QHashSeed::globalSeed();
+-        size_t operator()(const HT &t) const {
+-            return QHashPrivate::calculateHash(t, storedSeed);
+-        }
+-    };
+-
+-    struct node_guesstimate { void *next; size_t hash; T value; };
+-    static constexpr size_t bufferSize(size_t N) {
+-        return N * sizeof(void*) // bucket list
+-                + N * sizeof(node_guesstimate); // nodes
+-    }
+-
+-    char buffer[bufferSize(Prealloc)];
+-    std::pmr::monotonic_buffer_resource res{buffer, sizeof buffer};
+-    std::pmr::unordered_set<T, QHasher<T>> set{Prealloc, &res};
+-#else
+     class Set : public QSet<T> {
+         qsizetype setSize = 0;
+     public:
+@@ -66,23 +41,14 @@
+         }
+     };
+     Set set{Prealloc};
+-#endif
+     Q_DISABLE_COPY_MOVE(QDuplicateTracker);
+ public:
+     static constexpr inline bool uses_pmr =
+-        #ifdef __cpp_lib_memory_resource
+-            true
+-        #else
+             false
+-        #endif
+             ;
+     QDuplicateTracker() = default;
+     explicit QDuplicateTracker(qsizetype n)
+-#ifdef __cpp_lib_memory_resource
+-        : set{size_t(n), &res}
+-#else
+         : set{n}
+-#endif
+     {}
+     Q_DECL_DEPRECATED_X("Pass the capacity to reserve() to the ctor instead.")
+     void reserve(qsizetype n) { set.reserve(n); }

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -5,6 +5,10 @@ local name='qt6'
 local version=6.5.2
 local url='https://download.qt.io/official_releases/qt/6.5/6.5.2'
 local hash="${0:a:h}/checksums"
+local patches=(
+  "${0:a:h}/patches/0001-fix-macos-c++17-include.patch \
+  1edc79d5f097be86313a632df31c0643457a10dc155b58e05fb05d083283a00f"
+)
 
 local -a qt_components=(
   'qtbase'
@@ -64,18 +68,14 @@ patch() {
   autoload -Uz apply_patch
 
   log_info "Patch (%F{3}${target}%f)"
-
   cd ${dir}
 
   local patch
-  local _target
   local _url
   local _hash
-
   for patch (${patches}) {
-    read _target _url _hash <<< "${patch}"
-
-    if [[ ${target%%-*} == ${~_target} ]] apply_patch ${_url} ${_hash}
+    read _url _hash <<< "${patch}"
+    apply_patch ${_url} ${_hash}
   }
 }
 


### PR DESCRIPTION
### Description
Fixes compilation errors with AppleClang 15.

### Motivation and Context
AppleClang 15 implements the C++17 feature "polymorphic memory resources", but the linker guards this functionality behind the macOS 14 deployment target.

The guards implemented in Qt code cannot check for the deployment target, so to keep the C++17 standard, we need to patch out all uses of memory targets in code.

### How Has This Been Tested?
Successfully compiled Qt 6.5.2 on macOS 13.6 with AppleClang 15.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
