### PR TITLE
deps.windows: Patch curl CMake

### DIFF
--- a/deps.windows/30-curl.ps1
+++ b/deps.windows/30-curl.ps1
@@ -2,7 +2,13 @@ param(
     [string] $Name = 'curl',
     [string] $Version = '8.4.0',
     [string] $Uri = 'https://github.com/curl/curl.git',
-    [string] $Hash = 'd755a5f7c009dd63a61b2c745180d8ba937cbfeb'
+    [string] $Hash = 'd755a5f7c009dd63a61b2c745180d8ba937cbfeb',
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/curl/0001-Fix-curl-config-cmake-in.patch"
+            HashSum = "4b4ab217ff24875ad0fdb0a6e93f70938186113da885081d8fc99fc88205fb2d"
+        }
+    )
 )
 
 function Setup {

--- a/deps.windows/patches/curl/0001-Fix-curl-config-cmake-in.patch
+++ b/deps.windows/patches/curl/0001-Fix-curl-config-cmake-in.patch
@@ -1,0 +1,12 @@
+diff --git a/CMake/curl-config.cmake.in b/CMake/curl-config.cmake.in
+index 056907c4f..9adb96e0a 100644
+--- a/CMake/curl-config.cmake.in
++++ b/CMake/curl-config.cmake.in
+@@ -35,4 +35,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ check_required_components("@PROJECT_NAME@")
+ 
+ # Alias for either shared or static library
+-add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
++if(NOT TARGET @PROJECT_NAME@::libcurl)
++  add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
++endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add a patch for curl's CMake to fix an issue that causes configure failures for consumers of the resulting curl package if they call find_package(CURL) more than once.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to use curl 8.4.0 because it has CVE-2023-38545 fixed. This patch is hopefully temporary until curl fixes this in their repo.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've built curl locally with this patch applied. I haven't tested this against OBS Studio, but the fix looks correct. Will be able to test more easily after new obs-deps packages are available.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
