### PR TITLE
deps.qt: Add Qt patches

### DIFF
--- a/deps.qt/patches/Qt6/win/0001-CVE-2023-43114-6.5.patch
+++ b/deps.qt/patches/Qt6/win/0001-CVE-2023-43114-6.5.patch
@@ -1,0 +1,120 @@
+diff --git a/qtbase/src/gui/text/windows/qwindowsfontdatabase.cpp b/qtbase/src/gui/text/windows/qwindowsfontdatabase.cpp
+index 44cc7fe63e..e44d85a3cb 100644
+--- a/qtbase/src/gui/text/windows/qwindowsfontdatabase.cpp
++++ b/qtbase/src/gui/text/windows/qwindowsfontdatabase.cpp
+@@ -873,36 +873,70 @@ QT_WARNING_POP
+     return fontEngine;
+ }
+ 
+-static QList<quint32> getTrueTypeFontOffsets(const uchar *fontData)
++static QList<quint32> getTrueTypeFontOffsets(const uchar *fontData, const uchar *fileEndSentinel)
+ {
+     QList<quint32> offsets;
+-    const quint32 headerTag = *reinterpret_cast<const quint32 *>(fontData);
++    if (fileEndSentinel - fontData < 12) {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++        return offsets;
++    }
++
++    const quint32 headerTag = qFromUnaligned<quint32>(fontData);
+     if (headerTag != MAKE_TAG('t', 't', 'c', 'f')) {
+         if (headerTag != MAKE_TAG(0, 1, 0, 0)
+             && headerTag != MAKE_TAG('O', 'T', 'T', 'O')
+             && headerTag != MAKE_TAG('t', 'r', 'u', 'e')
+-            && headerTag != MAKE_TAG('t', 'y', 'p', '1'))
++            && headerTag != MAKE_TAG('t', 'y', 'p', '1')) {
+             return offsets;
++        }
+         offsets << 0;
+         return offsets;
+     }
++
++    const quint32 maximumNumFonts = 0xffff;
+     const quint32 numFonts = qFromBigEndian<quint32>(fontData + 8);
+-    for (uint i = 0; i < numFonts; ++i) {
+-        offsets << qFromBigEndian<quint32>(fontData + 12 + i * 4);
++    if (numFonts > maximumNumFonts) {
++        qCWarning(lcQpaFonts) << "Font collection of" << numFonts << "fonts is too large. Aborting.";
++        return offsets;
++    }
++
++    if (quintptr(fileEndSentinel - fontData) > 12 + (numFonts - 1) * 4) {
++        for (quint32 i = 0; i < numFonts; ++i)
++            offsets << qFromBigEndian<quint32>(fontData + 12 + i * 4);
++    } else {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
+     }
++
+     return offsets;
+ }
+ 
+-static void getFontTable(const uchar *fileBegin, const uchar *data, quint32 tag, const uchar **table, quint32 *length)
++static void getFontTable(const uchar *fileBegin, const uchar *fileEndSentinel, const uchar *data, quint32 tag, const uchar **table, quint32 *length)
+ {
+-    const quint16 numTables = qFromBigEndian<quint16>(data + 4);
+-    for (uint i = 0; i < numTables; ++i) {
+-        const quint32 offset = 12 + 16 * i;
+-        if (*reinterpret_cast<const quint32 *>(data + offset) == tag) {
+-            *table = fileBegin + qFromBigEndian<quint32>(data + offset + 8);
+-            *length = qFromBigEndian<quint32>(data + offset + 12);
+-            return;
++    if (fileEndSentinel - data >= 6) {
++        const quint16 numTables = qFromBigEndian<quint16>(data + 4);
++        if (fileEndSentinel - data >= 28 + 16 * (numTables - 1)) {
++            for (quint32 i = 0; i < numTables; ++i) {
++                const quint32 offset = 12 + 16 * i;
++                if (qFromUnaligned<quint32>(data + offset) == tag) {
++                    const quint32 tableOffset = qFromBigEndian<quint32>(data + offset + 8);
++                    if (quintptr(fileEndSentinel - fileBegin) <= tableOffset) {
++                        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++                        break;
++                    }
++                    *table = fileBegin + tableOffset;
++                    *length = qFromBigEndian<quint32>(data + offset + 12);
++                    if (quintptr(fileEndSentinel - *table) < *length) {
++                        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++                        break;
++                    }
++                    return;
++                }
++            }
++        } else {
++            qCWarning(lcQpaFonts) << "Corrupted font data detected";
+         }
++    } else {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
+     }
+     *table = 0;
+     *length = 0;
+@@ -915,8 +949,9 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+                                      QList<QFontValues> *values)
+ {
+     const uchar *data = reinterpret_cast<const uchar *>(fontData.constData());
++    const uchar *dataEndSentinel = data + fontData.size();
+ 
+-    QList<quint32> offsets = getTrueTypeFontOffsets(data);
++    QList<quint32> offsets = getTrueTypeFontOffsets(data, dataEndSentinel);
+     if (offsets.isEmpty())
+         return;
+ 
+@@ -924,7 +959,7 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+         const uchar *font = data + offsets.at(i);
+         const uchar *table;
+         quint32 length;
+-        getFontTable(data, font, MAKE_TAG('n', 'a', 'm', 'e'), &table, &length);
++        getFontTable(data, dataEndSentinel, font, MAKE_TAG('n', 'a', 'm', 'e'), &table, &length);
+         if (!table)
+             continue;
+         QFontNames names = qt_getCanonicalFontNames(table, length);
+@@ -934,7 +969,7 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+         families->append(std::move(names));
+ 
+         if (values || signatures)
+-            getFontTable(data, font, MAKE_TAG('O', 'S', '/', '2'), &table, &length);
++            getFontTable(data, dataEndSentinel, font, MAKE_TAG('O', 'S', '/', '2'), &table, &length);
+ 
+         if (values) {
+             QFontValues fontValues;
+-- 
+2.27.0.windows.1
+

--- a/deps.qt/patches/Qt6/win/0002-QTBUG-117779.patch
+++ b/deps.qt/patches/Qt6/win/0002-QTBUG-117779.patch
@@ -1,0 +1,110 @@
+From 581eecd59dcc02579eef337f54337fb4c41efa9a Mon Sep 17 00:00:00 2001
+From: Timothée Keller <timothee.keller@qt.io>
+Date: Tue, 10 Oct 2023 07:57:09 +0000
+Subject: [PATCH] Revert "Windows QPA: Move transient children with a window move"
+
+This reverts commit 530d092eae0579bbb88e95f853715cac214da636.
+
+Reason for revert: Moving transient children as a whole is too broad, and forces unrelated windows to have their position completely dependent on a transient parent.
+
+Fixes: QTBUG-117779
+Change-Id: I01312e26e95c8144c392eca33aec41f54aaa40b0
+Reviewed-by: Tor Arne Vestbø <tor.arne.vestbo@qt.io>
+(cherry picked from commit 614e0f1daa9da2c285e2fd3868f7ebfa9837164c)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 19471b215df898d605962473ce403f6f4793a549)
+---
+
+diff --git a/qtbase/src/plugins/platforms/windows/qwindowswindow.cpp b/qtbase/src/plugins/platforms/windows/qwindowswindow.cpp
+index af1b95c..0856043 100644
+--- a/qtbase/src/plugins/platforms/windows/qwindowswindow.cpp
++++ b/qtbase/src/plugins/platforms/windows/qwindowswindow.cpp
+@@ -947,7 +947,6 @@
+ 
+     result.geometry = obtainedGeometry;
+     result.restoreGeometry = frameGeometry(result.hwnd, topLevel);
+-    result.preMoveGeometry = obtainedGeometry;
+     result.fullFrameMargins = context->margins;
+     result.embedded = embedded;
+     result.hasFrame = hasFrame;
+@@ -2164,56 +2163,11 @@
+     }
+ }
+ 
+-QWindow *QWindowsWindow::topTransientOf(QWindow *w)
+-{
+-    while (QWindow *transientParent = w->transientParent())
+-        w = transientParent;
+-    return w;
+-}
+-
+-void QWindowsWindow::moveTransientChildren()
+-{
+-    // We need the topmost Transient parent since it is the window that will initiate
+-    // the chain of moves, and is the only one with an already up to date DPI, which we
+-    // need for the scaling.
+-    const QWindowsWindow *topTransient = QWindowsWindow::windowsWindowOf(topTransientOf(window()));
+-
+-    const QWindow *currentWindow = window();
+-    const QWindowList allWindows = QGuiApplication::allWindows();
+-    for (QWindow *w : allWindows) {
+-        if (w->transientParent() == currentWindow && w != currentWindow && w->isVisible()) {
+-            QWindowsWindow *transientChild = QWindowsWindow::windowsWindowOf(w);
+-
+-            RECT oldChildPos{};
+-            GetWindowRect(transientChild->handle(), &oldChildPos);
+-            const RECT oldParentPos = RECTfromQRect(preMoveRect());
+-
+-            const qreal scale =
+-                    QHighDpiScaling::roundScaleFactor(qreal(topTransient->savedDpi()) / QWindowsScreen::baseDpi) /
+-                    QHighDpiScaling::roundScaleFactor(qreal(transientChild->savedDpi()) / QWindowsScreen::baseDpi);
+-
+-            const RECT offset =
+-                    RECTfromQRect(QRect(scale * (oldChildPos.left - oldParentPos.left),
+-                                        scale * (oldChildPos.top - oldParentPos.top), 0, 0));
+-            const RECT newParentPos = RECTfromQRect(m_data.geometry);
+-            const RECT newChildPos { newParentPos.left + offset.left,
+-                                     newParentPos.top + offset.top,
+-                                     transientChild->geometry().width(),
+-                                     transientChild->geometry().height() };
+-
+-            SetWindowPos(transientChild->handle(), nullptr, newChildPos.left, newChildPos.top,
+-                         newChildPos.right, newChildPos.bottom, SWP_NOZORDER | SWP_NOACTIVATE);
+-        }
+-    }
+-}
+-
+ void QWindowsWindow::handleMoved()
+ {
+-    setPreMoveRect(geometry());
+     // Minimize/Set parent can send nonsensical move events.
+     if (!IsIconic(m_data.hwnd) && !testFlag(WithinSetParent))
+         handleGeometryChange();
+-    moveTransientChildren();
+ }
+ 
+ void QWindowsWindow::handleResized(int wParam, LPARAM lParam)
+diff --git a/qtbase/src/plugins/platforms/windows/qwindowswindow.h b/qtbase/src/plugins/platforms/windows/qwindowswindow.h
+index bd936ec..0d393ec 100644
+--- a/qtbase/src/plugins/platforms/windows/qwindowswindow.h
++++ b/qtbase/src/plugins/platforms/windows/qwindowswindow.h
+@@ -78,7 +78,6 @@
+ {
+     Qt::WindowFlags flags;
+     QRect geometry;
+-    QRect preMoveGeometry;
+     QRect restoreGeometry;
+     QMargins fullFrameMargins; // Do not use directly for windows, see FrameDirty.
+     QMargins customMargins;    // User-defined, additional frame for NCCALCSIZE
+@@ -223,11 +222,6 @@
+     QRect restoreGeometry() const { return m_data.restoreGeometry; }
+     void updateRestoreGeometry();
+ 
+-    static QWindow *topTransientOf(QWindow *w);
+-    QRect preMoveRect() const { return m_data.preMoveGeometry; }
+-    void setPreMoveRect(const QRect &rect) { m_data.preMoveGeometry = rect; }
+-    void moveTransientChildren();
+-
+     void setVisible(bool visible) override;
+     bool isVisible() const;
+     bool isExposed() const override { return testFlag(Exposed); }

--- a/deps.qt/patches/Qt6/win/0003-QTBUG-118117.patch
+++ b/deps.qt/patches/Qt6/win/0003-QTBUG-118117.patch
@@ -1,0 +1,35 @@
+From dc3c90402735667964709e0364cabe32645b40cc Mon Sep 17 00:00:00 2001
+From: Tor Arne Vestbø <tor.arne.vestbo@qt.io>
+Date: Tue, 17 Oct 2023 16:06:19 +0200
+Subject: [PATCH] Windows: Don't re-apply application badge if one has not been set
+
+We need to re-apply the application badge when the color scheme changes;
+when a task bar button is being created for the fist time; or after Explorer
+has crashed and re-started.
+
+But we should only do that if the user has set an application badge
+via our APIs. Otherwise we might end up clearing an existing badge
+that was set via the native APIs directly.
+
+Fixes: QTBUG-118117
+Change-Id: I1f1fecba44c118d4e3f7ef4119139c3ebd23f047
+Reviewed-by: Oliver Wolff <oliver.wolff@qt.io>
+(cherry picked from commit 8f2828683e2ac44a282e8f061de1c76925abcec1)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 6e2f3118731d13839faf63077cba1d141e7c0af5)
+---
+
+diff --git a/qtbase/src/plugins/platforms/windows/qwindowsintegration.cpp b/qtbase/src/plugins/platforms/windows/qwindowsintegration.cpp
+index 923e515..2598f19 100644
+--- a/qtbase/src/plugins/platforms/windows/qwindowsintegration.cpp
++++ b/qtbase/src/plugins/platforms/windows/qwindowsintegration.cpp
+@@ -797,7 +797,8 @@
+     // to a task bar button being created for the fist time or after
+     // Explorer had crashed and re-started. In any case, re-apply the
+     // badge so that everything is up to date.
+-    setApplicationBadge(m_applicationBadgeNumber);
++    if (m_applicationBadgeNumber)
++        setApplicationBadge(m_applicationBadgeNumber);
+ }
+ 
+ #if QT_CONFIG(vulkan)

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -9,6 +9,10 @@ param(
             PatchFile = "${PSScriptRoot}/patches/Qt6/win/0001-CVE-2023-43114-6.5.patch"
             HashSum = "882E4B8D0076FF78A9A679D77C77E02EDBF5CC09CA4E9EE8667BA3CB42A65443"
         }
+        @{
+            PatchFile = "${PSScriptRoot}/patches/Qt6/win/0002-QTBUG-117779.patch"
+            HashSum = "D082EA4F39F7EBF39B45A74B7EA141AB47E4E56B995C2DCE7FDE4A6A52E63AA9"
+        }
     )
 )
 

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -13,6 +13,10 @@ param(
             PatchFile = "${PSScriptRoot}/patches/Qt6/win/0002-QTBUG-117779.patch"
             HashSum = "D082EA4F39F7EBF39B45A74B7EA141AB47E4E56B995C2DCE7FDE4A6A52E63AA9"
         }
+        @{
+            PatchFile = "${PSScriptRoot}/patches/Qt6/win/0003-QTBUG-118117.patch"
+            HashSum = "9199DBF395694E1D592C2E86634DD8E84DBA4B70B8F55B365CF5141A00E38E23"
+        }
     )
 )
 

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -59,6 +59,18 @@ function Clean {
     }
 }
 
+function Patch {
+    Log-Information "Patch (${Target})"
+    Push-Location "${Directory}"
+
+    $Patches | ForEach-Object {
+        $Params = $_
+        Safe-Patch @Params
+    }
+
+    Pop-Location
+}
+
 function Configure {
     $OnOff = @('OFF', 'ON')
     $Options = @(

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -3,7 +3,13 @@ param(
     [string] $Version = '6.5.3',
     [string] $Uri = 'https://download.qt.io/official_releases/qt/6.5/6.5.3',
     [string] $Hash = "${PSScriptRoot}/checksums",
-    [array] $Targets = @('x64', 'x86')
+    [array] $Targets = @('x64', 'x86'),
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/Qt6/win/0001-CVE-2023-43114-6.5.patch"
+            HashSum = "882E4B8D0076FF78A9A679D77C77E02EDBF5CC09CA4E9EE8667BA3CB42A65443"
+        }
+    )
 )
 
 $QtComponents = @(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR contains four commits:

1. deps.qt: Restore Patch function for Windows Qt script
   The Patch function was left out of a previous rewrite.

2. deps.qt: Backport patch for CVE-2023-43114
   The CVE only affects Windows.

   Fixed in 6.5.4 and 6.6.0.

   https://www.qt.io/blog/security-update-regarding-cve-2023-43114
   https://codereview.qt-project.org/c/qt/qtbase/+/504321
   http://bugreports.qt.io/browse/QTBUG-116773

3. deps.qt: Backport patch for QTBUG-117779

   Fix a bug on Windows where child windows would move with the parent
   window and also resize to their minimum size.

   Fixed in 6.5.4, 6.6.1, and 6.7.

   https://bugreports.qt.io/browse/QTBUG-117779
   https://bugreports.qt.io/browse/QTBUG-118118
   https://bugreports.qt.io/browse/QTBUG-118217

4. deps.qt: Backport patch for QTBUG-118117

   Fix a bug on Windows that caused taskbar icon overlays to be reset by Qt
   if previously set via native Windows API calls.

   Fixed in 6.5.4, 6.6.1, and 6.7.

   https://bugreports.qt.io/browse/QTBUG-118117

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Qt 6.5.4 is Commercial LTS only. Don't want these bugs in our release.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
On Windows 11, I built Qt locally with these patches and built OBS Studio against that version of Qt. I verified that QTBUG-117779  and QTBUG-118117 were no longer present.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
