### PR TITLE
CI: Fix issues introduced by CMake version changes when using build caches

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -37,6 +37,8 @@ runs:
             ;;
         esac
 
+        deps_hash=$(echo "${deps_hash}\n$(cmake --version)" | sha256sum | cut -d " " -f 1)
+
         echo "hash=${deps_hash:0:9}" >> $GITHUB_OUTPUT
 
     - name: Restore Dependencies from Cache

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -162,6 +162,35 @@ jobs:
           ./Build-Dependencies.ps1 @Params
           Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
 
+      - name: Build VPL Debug
+        if: matrix.target == 'x64'
+        shell: pwsh
+        run: |
+          # Build VPL Debug
+
+          $Params = @{
+            Target = '${{ matrix.target }}'
+            Configuration = 'Debug'
+            Dependencies = 'vpl'
+          }
+
+          ./Build-Dependencies.ps1 @Params
+          Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
+
+      - name: Build qrcodegencpp Debug
+        shell: pwsh
+        run: |
+          # Build qrcodegencpp Debug
+
+          $Params = @{
+            Target = '${{ matrix.target }}'
+            Configuration = 'Debug'
+            Dependencies = 'qrcodegencpp'
+          }
+
+          ./Build-Dependencies.ps1 @Params
+          Remove-Item -Recurse -Force ${{ github.workspace }}/windows_build_temp
+
       - name: Build Windows Dependencies
         uses: ./.github/actions/build-deps
         with:


### PR DESCRIPTION
### Description
Adds the CMake version used on a runner to the generated hash used for build caches and adds VPL and QR-Code-Generator to scheduled builds.

### Motivation and Context
CMake's installation scripts will automatically remove old CMake package installations if the `<project>-targets.cmake` file to be installed differs from the one found at the installation destination.

This process will also remove any configuration-related target files found in that directory. This currently leads to the restored build directory from the GitHub Action cache to remove the files installed by the step to create the Debug configuration variant.

Forcing the cache restoration to miss if the CMake version used for the cache differs from the one currently installed on runners ensures that both steps will use the same underlying CMake version.

### How Has This Been Tested?
Will require CMake changes on a runner to show its actual effectiveness, but it was confirmed that using the same CMake version for a debug configuration run followed by a release run will not remove the target files.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
