### PR TITLE
deps.ffmpeg: Update mbedTLS to 3.5.1

### DIFF
--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -3,15 +3,15 @@ autoload -Uz log_debug log_error log_info log_status log_output
 ## Dependency Information
 local name='mbedtls'
 local -A versions=(
-  macos 3.4.0
-  linux 3.4.0
-  windows 3.4.0
+  macos 3.5.1
+  linux 3.5.1
+  windows 3.5.1
 )
 local url='https://github.com/Mbed-TLS/mbedtls.git'
 local -A hashes=(
-  macos 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
-  linux 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
-  windows 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
+  macos edb8fec9882084344a314368ac7fd957a187519c
+  linux edb8fec9882084344a314368ac7fd957a187519c
+  windows edb8fec9882084344a314368ac7fd957a187519c
 )
 local -a patches=(
   "macos ${0:a:h}/patches/mbedtls/0001-enable-posix-threading-support.patch \

--- a/deps.windows/10-mbedtls.ps1
+++ b/deps.windows/10-mbedtls.ps1
@@ -1,8 +1,8 @@
 param(
     [string] $Name = 'mbedtls',
-    [string] $Version = '3.4.0',
+    [string] $Version = '3.5.1',
     [string] $Uri = 'https://github.com/Mbed-TLS/mbedtls.git',
-    [string] $Hash = '1873d3bfc2da771672bd8e7e8f41f57e0af77f33',
+    [string] $Hash = 'edb8fec9882084344a314368ac7fd957a187519c',
     [array] $Patches = @(
         @{
             PatchFile = "${PSScriptRoot}/patches/mbedtls/0001-enable-dtls-srtp-support.patch"


### PR DESCRIPTION
### Description
A simple update of mbedTLS from 3.4.0 to 3.5.1

### Motivation and Context
This fixed building obs-deps ffmpeg on macOS for me.
Apparently has something to do with https://github.com/Mbed-TLS/mbedtls/pull/7098

### How Has This Been Tested?
Successfully built with `clang 15.0.0 "Apple clang version 15.0.0 (clang-1500.0.28.1.1)` on my MacBook Pro

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
