### PR TITLE
deps.ffmpeg: Fix MbedTLS compile error with Clang 15

### DIFF
--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -73,7 +73,7 @@ config() {
     -DGEN_FILES=OFF
   )
 
-  if [[ ${config} == Release ]] args+=(-DCMAKE_C_FLAGS="-std=c17 -g")
+  if [[ ${config} == Release ]] args=(${args//-DCMAKE_C_FLAGS=/-DCMAKE_C_FLAGS=-g })
 
   log_info "Config (%F{3}${target}%f)"
   cd "${dir}"


### PR DESCRIPTION
### Description
Fixes compilation errors of MbedTLS when compiling with Clang 15.

### Motivation and Context
Clang 15 is the default compiler version on current macOS versions. The only reason this bug doesn't occur on CI is because the macOS 13 runners (and associated default Xcode version) are outdated.

### How Has This Been Tested?
Tested with Clang 15 on macOS 14.2.1.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
