### PR TITLE
deps.macos: Fix installation of universal FreeType libraries

### DIFF
--- a/deps.macos/60-freetype.zsh
+++ b/deps.macos/60-freetype.zsh
@@ -89,6 +89,8 @@ install() {
 
   cd ${dir}/build_${arch}
 
+  if [[ ${arch} == universal ]] sed -i '' -E -e 's/build_(x86_64|arm64)/build_universal/g' Makefile
+
   PATH="${(j.:.)cc_path}" progress make install
 }
 


### PR DESCRIPTION
### Description
Fixes hard-coded path in Makefile by FreeType's build system to represent the manually created build directory for combined architectures.

### Motivation and Context
Ensure that generated universal libraries are installed by generated Makefile and not just the architecture used as the base for the combined build directory.

### How Has This Been Tested?
Tested on macOS 14.1.2 and building universal architecture variant for FreeType2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
