### PR TITLE
utils.pwsh: Add support for curl resume

### DIFF
--- a/utils.pwsh/Invoke-SafeWebRequest.ps1
+++ b/utils.pwsh/Invoke-SafeWebRequest.ps1
@@ -64,6 +64,11 @@ function Invoke-SafeWebRequest {
                 '--output', "$OutFile"
             )
 
+            $CurlVersionResult = $($(Invoke-External curl --version) -join ' ') -match 'curl (?<CurlVersion>\d+\.\d+\.\d+)'
+            if ( ( $Matches.CurlVersion -ge '8.5.0' ) -and $Resume ) {
+                $CurlOptions += @('-C', '-')
+            }
+
             Invoke-External curl @CurlOptions @HeaderStrings $Uri
 
             $NewHash = Get-FileHash -Path $OutFile -Algorithm $Algorithm

--- a/utils.pwsh/Invoke-SafeWebRequest.ps1
+++ b/utils.pwsh/Invoke-SafeWebRequest.ps1
@@ -57,7 +57,14 @@ function Invoke-SafeWebRequest {
                 }
             }
 
-            Invoke-External curl --fail --location $(if ( $Env:CI -eq $null ) { '--progress-bar' }) --output $OutFile @HeaderStrings $Uri
+            $CurlOptions = @(
+                '--fail'
+                '--location'
+                $(if ( $Env:CI -eq $null ) { '--progress-bar' })
+                '--output', "$OutFile"
+            )
+
+            Invoke-External curl @CurlOptions @HeaderStrings $Uri
 
             $NewHash = Get-FileHash -Path $OutFile -Algorithm $Algorithm
         }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Note that there is a bug in curl that can prevent curl from successfully interpreting a fully downloaded file as completed. The bug was fixed on October 30, 2023 and is not yet available on curl included with Windows.

Fixed in curl 8.5.0.
https://github.com/curl/curl/commit/225db9196a71a19132a4c334f256b59854afc70c

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I noticed that we have the Resume parameter, but that it wasn't implemented. I wanted to implement it to have a way to skip re-downloading a file that was already downloaded. SkipDeps skips build dependencies. SkipUnpack skips git checkouts and archive extraction but not downloads.

Alternatively, we could add something like SkipDownload and implement that, and remove the Resume parameter.

It may be important to note that due to us invoking MSYS2, the copy of curl from there can take precedence in PATH. From my recent tests, MSYS2 curl (8.1.1 on my machine) is older than the one shipped with Windows, so this may not work unless we attempt to fix the curl executable's path to the Windows copy (which should always be at `C:\Windows\System32\curl.exe`) or locate it and save its path before invoking MSYS2 (with `where.exe curl.exe`).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally with curl 8.4.0 (what is currently shipped on Windows) to ensure that the code did not currently run.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
