### PR TITLE
CI: Fix cache refresh in scheduled nightly builds

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -51,7 +51,7 @@ jobs:
             fi
           done <<< \
           "$(gh api repos/${GITHUB_REPOSITORY}/actions/caches \
-            --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")) | select(.key|test(".+-(qt6|deps)-.+")) | select(.key|test(".+ffmpeg.+")|not) | {id, key} | join(";")')"
+            --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")) | select(.key|test(".+-(qt6|ffmpeg|deps)-.+")) | {id, key} | join(";")')"
           echo '::endgroup::'
 
           echo '::group::Processing pull request cache entries'
@@ -76,6 +76,7 @@ jobs:
   ffmpeg-macos-build:
     name: Build FFmpeg for macOS
     runs-on: macos-13
+    needs: cache-cleanup
     strategy:
       fail-fast: true
       matrix:
@@ -129,6 +130,7 @@ jobs:
   ffmpeg-windows-build:
     name: Build FFmpeg for Windows
     runs-on: windows-2022
+    needs: cache-cleanup
     strategy:
       fail-fast: true
       matrix:
@@ -157,6 +159,7 @@ jobs:
   macos-build:
     name: Build macOS Dependencies
     runs-on: macos-13
+    needs: cache-cleanup
     strategy:
       fail-fast: true
       matrix:
@@ -210,6 +213,7 @@ jobs:
   windows-build:
     name: Build Windows Dependencies
     runs-on: windows-2022
+    needs: cache-cleanup
     strategy:
       fail-fast: true
       matrix:
@@ -282,6 +286,7 @@ jobs:
   macos-qt6-build:
     name: Build Qt6 (macOS)
     runs-on: macos-13
+    needs: cache-cleanup
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}
@@ -322,6 +327,7 @@ jobs:
   windows-qt6-build:
     name: Build Qt6 (Windows)
     runs-on: windows-2022
+    needs: cache-cleanup
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
### Description
Add cache cleanup job as precondition for build jobs in scheduled workflow.

### Motivation and Context
Avoids a possible race condition between cache cleanup and use of caches in the build jobs.

Also includes FFmpeg caches in the cleanup as the build action has been fully updated with expected scheduled cleanups.

Fixes cache save warnings emitted in scheduled FFmpeg build jobs due to original cache not being removed before its run.

### How Has This Been Tested?
Needs final test on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
