### PR TITLE
CI: Update macOS jobs to use macOS 14 runners

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,7 +55,7 @@ jobs:
 
   ffmpeg-macos-build:
     name: Build FFmpeg for macOS
-    runs-on: macos-13
+    runs-on: macos-14
     needs: pre-checks
     strategy:
       fail-fast: true
@@ -189,7 +189,7 @@ jobs:
 
   ffmpeg-package-universal:
     name: Build FFmpeg (Universal)
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [pre-checks, ffmpeg-macos-build]
     steps:
       - name: Checkout
@@ -213,7 +213,7 @@ jobs:
 
   macos-build:
     name: Build macOS Dependencies
-    runs-on: macos-13
+    runs-on: macos-14
     needs: pre-checks
     strategy:
       fail-fast: true
@@ -299,7 +299,7 @@ jobs:
 
   macos-package-universal:
     name: Build macOS Dependencies (Universal)
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [pre-checks, macos-build]
     steps:
       - name: Checkout
@@ -323,7 +323,7 @@ jobs:
 
   macos-qt6-build:
     name: Build Qt6 (macOS)
-    runs-on: macos-13
+    runs-on: macos-14
     needs: pre-checks
     defaults:
       run:
@@ -394,7 +394,7 @@ jobs:
 
   macos-qt6-package:
     name: Create macOS Qt6 (${{ matrix.target }})
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -75,7 +75,7 @@ jobs:
 
   ffmpeg-macos-build:
     name: Build FFmpeg for macOS
-    runs-on: macos-13
+    runs-on: macos-14
     needs: cache-cleanup
     strategy:
       fail-fast: true
@@ -158,7 +158,7 @@ jobs:
 
   macos-build:
     name: Build macOS Dependencies
-    runs-on: macos-13
+    runs-on: macos-14
     needs: cache-cleanup
     strategy:
       fail-fast: true
@@ -285,7 +285,7 @@ jobs:
 
   macos-qt6-build:
     name: Build Qt6 (macOS)
-    runs-on: macos-13
+    runs-on: macos-14
     needs: cache-cleanup
     defaults:
       run:


### PR DESCRIPTION
### Description
Updates macOS jobs to use macOS 14-based runners.

### Motivation and Context
Enables macOS jobs to use environment similar to expected local build environments and makes use of the performance benefits of Apple Silicon-based hardware.

### How Has This Been Tested?
Needs final testing on CI.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
