### PR TITLE
deps.ffmpeg: Force classic linker for AppleClang 15.0.0+

### DIFF
--- a/deps.ffmpeg/40-x264.zsh
+++ b/deps.ffmpeg/40-x264.zsh
@@ -73,8 +73,26 @@ config() {
       autoload -Uz universal_config && universal_config
       return
       ;;
-    macos-arm64) args+=(--host="aarch64-apple-darwin${target_config[darwin_target]}") ;;
-    macos-x86_64) args+=(--host="x86_64-apple-darwin${target_config[darwin_target]}") ;;
+    macos-arm64)
+      args+=(--host="aarch64-apple-darwin${target_config[darwin_target]}")
+
+      local clang_version=$(clang --version | head -1 | cut -d ' ' -f 4)
+
+      autoload -Uz is-at-least
+      if is-at-least 15.0.0 ${clang_version}; then
+        ld_flags+=(-Wl,-ld_classic)
+      fi
+      ;;
+    macos-x86_64)
+      args+=(--host="x86_64-apple-darwin${target_config[darwin_target]}")
+
+      local clang_version=$(clang --version | head -1 | cut -d ' ' -f 4)
+
+      autoload -Uz is-at-least
+      if is-at-least 15.0.0 ${clang_version}; then
+        ld_flags+=(-Wl,-ld_classic)
+      fi
+      ;;
     windows-x*)
       args+=(
         --host="${target_config[cross_prefix]}-pc-mingw32"

--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -89,6 +89,13 @@ config() {
         ${ld_flags}
       )
 
+      local clang_version=$(clang --version | head -1 | cut -d ' ' -f 4)
+
+      autoload -Uz is-at-least
+      if is-at-least 15.0.0 ${clang_version}; then
+        ff_ldflags+=(-Wl,-ld_classic)
+      fi
+
       args+=(
         --cc=clang
         --cxx=clang++


### PR DESCRIPTION
### Description
Forces classic linker mode with AppleClang 15 on macOS.

### Motivation and Context
Works around linker issues introduced by Xcode 15 beta 2 (tracked as FB13208302).

### How Has This Been Tested?
Tested locally on macOS 14.3.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
