### PR TITLE
deps.ffmpeg: Enable runtime CPU detection for AOM to fix ARM64 crashes

### DIFF
--- a/deps.ffmpeg/40-aom.zsh
+++ b/deps.ffmpeg/40-aom.zsh
@@ -69,7 +69,7 @@ config() {
   )
 
   case ${target} {
-    macos-*) args+=(-DCONFIG_RUNTIME_CPU_DETECT=0 -DCMAKE_TOOLCHAIN_FILE="build/cmake/toolchains/${target_config[cmake_arch]}-macos.cmake") ;;
+    macos-*) args+=(-DCMAKE_TOOLCHAIN_FILE="build/cmake/toolchains/${target_config[cmake_arch]}-macos.cmake") ;;
     windows-x*) args+=(-DCMAKE_TOOLCHAIN_FILE="build/cmake/toolchains/${target_config[cmake_arch]}-mingw-gcc.cmake")
   }
 


### PR DESCRIPTION
### Description
Enables AOM runtime CPU detection on macOS.

### Motivation and Context
Runtime CPU detection in AOM has been extended to properly detect ARM64 CPUs and enable NEON features if possible - disabling the runtime detection has been found to lead to crashes when attempting to record using AOM on Apple Silicon Macs.

Fixes https://github.com/obsproject/obs-studio/issues/10226.

### How Has This Been Tested?
Tested on macOS 14.3.1 doing AOM recordings with an updated `libavcodec.dylib` inserted into OBS app bundle.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
