### PR TITLE
CI: Force use of Xcode 15.2 to fix runtime crashes on older macOS

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,6 +78,10 @@ jobs:
       - name: Setup Environment
         id: setup
         run: |
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::endgroup::'
+
           local -a to_remove=()
 
           for formula (llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile \
@@ -238,6 +242,10 @@ jobs:
         run: |
           : Setup Environment
 
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::endgroup::'
+
           to_remove=()
 
           for formula (llvm gcc) {
@@ -336,6 +344,10 @@ jobs:
         id: setup
         run: |
           : Setup Environment
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::endgroup::'
+
           local -a to_remove=()
 
           for formula (llvm gcc) {

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -98,6 +98,11 @@ jobs:
       - name: Setup Environment
         id: setup
         run: |
+          : Setup Environment
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::endgroup::'
+
           local -a to_remove=()
 
           for formula (llvm gcc postgresql openjdk sox libsndfile flac libvorbis opusfile \
@@ -182,6 +187,9 @@ jobs:
         id: setup
         run: |
           : Setup Environment
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::endgroup::'
 
           to_remove=()
 
@@ -298,6 +306,10 @@ jobs:
         id: setup
         run: |
           : Setup Environment
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::endgroup::'
+
           local -a to_remove=()
 
           for formula (llvm gcc) {


### PR DESCRIPTION
### Description
Force use of Xcode 15.2 in macOS-based runners.

### Motivation and Context
Xcode 15.0.1 had a bug which lead to binaries crashing on macOS 12 or older when compiled with weak definitions (FB13097713).

Mainly exhibited by use of Qt in OBS Studio: https://bugreports.qt.io/browse/QTBUG-119848

### How Has This Been Tested?
Needs to be tested by building OBS with updated dependencies and generated version of OBS run on macOS 12 or macOS 11.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
