### PR TITLE
deps.qt: Add Qt Designer

### DIFF
--- a/deps.qt/checksums/qttools-everywhere-src-6.6.3.tar.xz.sha256
+++ b/deps.qt/checksums/qttools-everywhere-src-6.6.3.tar.xz.sha256
@@ -1,0 +1,1 @@
+aa6d4c822d8cb74066ef30ab42283ac24e5cc702f33e6d78a9ebef5b0df91bc0  qttools-everywhere-src-6.6.3.tar.xz

--- a/deps.qt/checksums/qttools-everywhere-src-6.6.3.zip.sha256
+++ b/deps.qt/checksums/qttools-everywhere-src-6.6.3.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">7B933328C395E1A5ED919F64D16E51486CF6784C0FD8BAF5DB380C3CA9CD18D4</S>
+      <S N="Path">qttools-everywhere-src-6.6.3.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -12,6 +12,7 @@ $QtComponents = @(
     'qtshadertools'
     'qtmultimedia'
     'qtsvg'
+    'qttools'
 )
 
 $Directory = 'qt6'
@@ -222,6 +223,18 @@ function Qt-Add-Submodules {
                 $ComponentOptions += @(
                     '-DINPUT_tiff:STRING=qt'
                     '-DINPUT_webp:STRING=qt'
+                )
+            }
+            qttools {
+                $ComponentOptions += @(
+                    '-DFEATURE_assistant:BOOL=OFF'
+                    '-DFEATURE_designer:BOOL=ON'
+                    '-DFEATURE_linguist:BOOL=OFF'
+                    '-DFEATURE_pixeltool:BOOL=OFF'
+                    '-DFEATURE_qtattributionsscanner:BOOL=OFF'
+                    '-DFEATURE_qtdiag:BOOL=OFF'
+                    '-DFEATURE_qtplugininfo:BOOL=OFF'
+                    '-DQT_BUILD_TOOLS_BY_DEFAULT:BOOL=ON'
                 )
             }
         }

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -216,9 +216,9 @@ qt_add_submodules() {
           -DFEATURE_designer:BOOL=ON
           -DFEATURE_linguist:BOOL=OFF
           -DFEATURE_pixeltool:BOOL=OFF
+          -DFEATURE_qtattributionsscanner:BOOL=OFF
           -DFEATURE_qtdiag:BOOL=OFF
           -DFEATURE_qtplugininfo:BOOL=OFF
-          -DFEATURE_qtattributionsscanner:BOOL=OFF
           -DQT_BUILD_TOOLS_BY_DEFAULT:BOOL=ON
         )
       fi

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -16,6 +16,7 @@ local -a qt_components=(
   'qtshadertools'
   'qtmultimedia'
   'qtsvg'
+  'qttools'
 )
 
 local dir='qt6'
@@ -209,6 +210,18 @@ qt_add_submodules() {
 
       local -a _args=(${common_cmake_flags})
       if [[ ${component} == qtimageformats ]] _args+=(-DINPUT_tiff:STRING=qt -DINPUT_webp:STRING=qt)
+      if [[ ${component} == qttools ]]; then
+        _args+=(
+          -DFEATURE_assistant:BOOL=OFF
+          -DFEATURE_designer:BOOL=ON
+          -DFEATURE_linguist:BOOL=OFF
+          -DFEATURE_pixeltool:BOOL=OFF
+          -DFEATURE_qtdiag:BOOL=OFF
+          -DFEATURE_qtplugininfo:BOOL=OFF
+          -DFEATURE_qtattributionsscanner:BOOL=OFF
+          -DQT_BUILD_TOOLS_BY_DEFAULT:BOOL=ON
+        )
+      fi
 
       pushd ${dir}/${component}
       log_debug "CMake configuration options: ${_args}'"


### PR DESCRIPTION
### Description

Build Qt Designer with our Qt deps 

### Motivation and Context

We should have always have a readily available version of designer people can use without having to suffer through Qt's maintenance tool and download like 3 GB of Qt builds and/or Qt Creator which may or may not be built against an older Qt version.

Additionally this avoids issues where people use "whatever they had insatlled" which may not match the version OBS is using (on macOS/Windows at least) and make changes to the XML format that don't match the shipping version.

Should also help unblock https://github.com/obsproject/obs-studio/pull/10419

### How Has This Been Tested?

We'll see if we compile ey?

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
