### PR TITLE
deps.ffmpeg: Update libdatachannel to 0.21.0

### DIFF
--- a/deps.ffmpeg/70-libdatachannel.ps1
+++ b/deps.ffmpeg/70-libdatachannel.ps1
@@ -1,8 +1,8 @@
 param(
     [string] $Name = 'libdatachannel',
-    [string] $Version = 'v0.20.1',
+    [string] $Version = 'v0.21.0',
     [string] $Uri = 'https://github.com/paullouisageneau/libdatachannel.git',
-    [string] $Hash = '7841d9f34cf9bd735958ae203a2536c14240c8a5',
+    [string] $Hash = '9d5c46b8f506943727104d766e5dad0693c5a223',
     [switch] $ForceShared = $true
 )
 

--- a/deps.ffmpeg/70-libdatachannel.zsh
+++ b/deps.ffmpeg/70-libdatachannel.zsh
@@ -2,9 +2,9 @@ autoload -Uz log_debug log_error log_info log_status log_output
 
 ## Dependency Information
 local name='libdatachannel'
-local version='v0.20.1'
+local version='v0.21.0'
 local url='https://github.com/paullouisageneau/libdatachannel.git'
-local hash='7841d9f34cf9bd735958ae203a2536c14240c8a5'
+local hash='9d5c46b8f506943727104d766e5dad0693c5a223'
 
 ## Dependency Overrides
 local -i shared_libs=1


### PR DESCRIPTION
This updates to libdatachannel 0.21.0

### Motivation and Context
* This fixes https://github.com/obsproject/obs-studio/issues/10564
* Adds support for WHEP (Accepting H264 and Opus)
* Add supports for STUN/TURN (Implement WHIP spec more)
* Bug fixes and crashes (not reported by OBS users)

### How Has This Been Tested?
Tested on Linux. I am looking for Mac/Windows testers now

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
