### PR TITLE
deps.macos: Fix incorrect CMake args and missing verbose logging in libajantv2 script

### DIFF
--- a/deps.macos/20-libajantv2.zsh
+++ b/deps.macos/20-libajantv2.zsh
@@ -34,11 +34,16 @@ config() {
 
   args=(
     ${cmake_flags}
-    -DAJA_BUILD_OPENSOURCE=ON
-    -DAJA_BUILD_APPS=OFF
+    -DAJA_BUILD_SHARED="${_onoff[(( shared_libs + 1 ))]}"
+    -DAJANTV2_DISABLE_DEMOS=ON
+    -DAJANTV2_DISABLE_DRIVER=ON
+    -DAJANTV2_DISABLE_TESTS=ON
+    -DAJANTV2_DISABLE_TOOLS=ON
+    -DAJANTV2_DISABLE_PLUGINS=ON
     -DAJA_INSTALL_SOURCES=OFF
     -DAJA_INSTALL_HEADERS=ON
-    -DAJA_BUILD_SHARED="${_onoff[(( shared_libs + 1 ))]}"
+    -DAJA_INSTALL_MISC=OFF
+    -DAJA_INSTALL_CMAKE=OFF
   )
 
   cd ${dir}

--- a/deps.macos/20-libajantv2.zsh
+++ b/deps.macos/20-libajantv2.zsh
@@ -57,7 +57,15 @@ build() {
   log_info "Build (%F{3}${target}%f)"
 
   cd ${dir}
-  cmake --build build_${arch} --config ${config}
+  
+  args=(
+    --build build_${arch}
+    --config ${config}
+  )
+
+  if (( _loglevel > 1 )) args+=(--verbose)
+
+  cmake ${args}
 }
 
 install() {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change addresses some of the feedback provided to me by PatTheMav via Discord regarding the recently merged PR https://github.com/obsproject/obs-deps/pull/233.

I've updated the Mac libajantv2 build script to use the correct updated CMake variable args for the new libajantv2 repo. This change makes the CMake variable args consistent across all three supported platform build scripts (Win, Mac, Flatpak).

I've also added the ability to enable verbose CMake logging in the macOS libajantv2 script.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The libajantv2 build script CMake variable args were updated in the libajantv2 Windows and Flatpak scripts in the recent PR https://github.com/obsproject/obs-deps/pull/233 but accidentally left unchanged in the macOS script. This means that the macOS build leaves a bunch of unintended cruft in the output dir (apps, tools, etc).

I'd also neglected to add the ability to handle the specification of verbose debug logging. This PR remedies that as well, per Pat's feedback.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Did a quick spot check on my Mac Mini by building libajantv2 with the updated CMake variable args and checking that the output dir only contains the static lib and headers.

Tested the vebose logging by running the Mac build script with `--debug` and `--verbose` and verified that verbose compiler output was printed to the console during build.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
