### PR TITLE
deps.ffmpeg: Enable Media Foundation

### DIFF
--- a/deps.ffmpeg/99-ffmpeg.ps1
+++ b/deps.ffmpeg/99-ffmpeg.ps1
@@ -88,7 +88,6 @@ function Configure {
         '--disable-sdl2'
         '--disable-doc'
         '--disable-postproc'
-        '--disable-mediafoundation'
         $(if ( ! $script:Shared ) { ('--pkg-config-flags=' + "'--static'") })
         $(if ( $Configuration -eq 'Debug' ) { '--enable-debug' } else { '--disable-debug' })
         $(if ( $Configuration -eq 'RelWithDebInfo' ) { '--disable-stripping' })

--- a/deps.ffmpeg/99-ffmpeg.zsh
+++ b/deps.ffmpeg/99-ffmpeg.zsh
@@ -184,7 +184,6 @@ config() {
         --cross-prefix="${target_config[cross_prefix]}-w64-mingw32-"
         --pkg-config=pkg-config
         --enable-cross-compile
-        --disable-mediafoundation
       )
 
       if [[ ${arch} == x64 ]] args+=(--enable-libaom --enable-libsvtav1)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

It was disabled to workaround issues with N editions of Windows.

Since a while FFmpeg is patched to dynamically load MFPlat.DLL rather than being directly linked to it, fixing the issues.

https://github.com/FFmpeg/FFmpeg/commit/1cb601ad10313981209a5918fc36a968068fc0ec

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I fixed it a while ago, I had doubt it fixed it since mstorsjo added back `-lmfuuid` to fix building with MSVC.
But Rodney told me that it's a static library, so a non-issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I did not test to run OBS with this on Windows N.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
