### PR TITLE
deps.ffmpeg: Fix Visual Studio ID/version for librist

### DIFF
--- a/deps.ffmpeg/70-librist.ps1
+++ b/deps.ffmpeg/70-librist.ps1
@@ -53,7 +53,7 @@ function Configure {
     }
 
     $VisualStudioData = Find-VisualStudio
-    $VisualStudioId = ($VisualStudioData.DisplayName -split ' ')[3]
+    $VisualStudioId = ($VisualStudioData.DisplayName -split ' ')[-1]
 
     $Options = @(
         '--buildtype', "$($ConfigStrings[$Configuration])"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The year/ID component of the Visual Studio display name is not always the fourth token. As far as I can tell, it is always the last token, so we can just get that. This is what we do in Setup-Target.ps1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
See also:
* #174
* #178

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I checked the syntax locally with a `$VisualStudioData` set to a copy of "Visual Studio Build Tools 2022", which is the known offender for the current syntax.

```
PS C:\> $VisualStudioData

InstanceId          : a63227f3
DisplayName         : Visual Studio Build Tools 2022
InstallationVersion : 17.10.35027.167
InstallationPath    : C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools
InstallDate         : 5/30/2023 1:17:32 PM

PS C:\> ($VisualStudioData.DisplayName -split ' ')[3]
Tools
PS C:\> ($VisualStudioData.DisplayName -split ' ')[-1]
2022
```

I did not do a full run of the build script, but I did not think it required here.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
