### PR TITLE
deps.ffmpeg: Remove MbedTLS CMake files from macOS FFmpeg package

### DIFF
--- a/build-deps.zsh
+++ b/build-deps.zsh
@@ -87,6 +87,7 @@ package() {
 
     rm -rf -- lib/^(*.dylib|*.a|*.so*|*.lib|*.framework|*.dSYM|cmake)(N)
     rm -rf -- lib/(libpcre*|libpng*|libfreetype.a)(N)
+    rm -rf -- lib/cmake/MbedTLS(N)
     rm -rf -- bin/^(*.exe|*.dll|*.pdb|swig)(N)
 
     if [[ ${PACKAGE_NAME} == ffmpeg ]] rm -rf -- lib/*.a(N)


### PR DESCRIPTION
### Description
Removes MbedTLS CMake package files for macOS FFmpeg builds.

### Motivation and Context
Once the project switches MbedTLS 3.6+, there needs to be a way to distinguish between older and newer versions on the obs-studio side.

The path of least resistance is to use CMake package-based discovery for versions 3.6+ and find module-based discovery for older versions, which requires the older (current as of time of the commit) versions to not provide a CMake package as part of obs-deps.

> [!NOTE]
> Once MbedTLS is updated to version 3.6+, this removal will need to be removed again.

### How Has This Been Tested?
Tested removal on current `obs-deps` with an updated `obs-studio` to opportunistically use package discovery mode and observe automatic fallback to find module to discover MbedTLS as provided by current dependencies.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
