### PR TITLE
deps.qt: Update Qt 6.6.3 download links to fix nightly builds

### DIFF
--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -1,7 +1,7 @@
 param(
     [string] $Name = 'qt6',
     [string] $Version = '6.6.3',
-    [string] $Uri = 'https://download.qt.io/official_releases/qt/6.6/6.6.3',
+    [string] $Uri = 'https://download.qt.io/archive/qt/6.6/6.6.3',
     [string] $Hash = "${PSScriptRoot}/checksums",
     [array] $Targets = @('x64')
 )

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -3,7 +3,7 @@ autoload -Uz log_debug log_error log_info log_status log_output
 ## Dependency Information
 local name='qt6'
 local version=6.6.3
-local url='https://download.qt.io/official_releases/qt/6.6/6.6.3'
+local url='https://download.qt.io/archive/qt/6.6/6.6.3'
 local hash="${0:a:h}/checksums"
 local -a patches=(
   "macos ${0:a:h}/patches/Qt6/mac/0001-QTBUG-121351.patch \


### PR DESCRIPTION
### Description
Update download links for Qt 6.6.3 to unbreak scheduled nightly builds.

### Motivation and Context
Qt 6.6 is considered a historical version of Qt 6 and has thus been archived and is not available from the official releases directory anymore.

### How Has This Been Tested?
Requires test run on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
