### PR TITLE
CI: Fix missing arm64 configuration for scheduled Windows FFmpeg builds

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -145,6 +145,10 @@ jobs:
           - target: x64
             config: Release
             type: static
+          - target: arm64
+            config: Release
+            type: static
+
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
### Description
Adds missing ARM64-specific configuration to the build matrix of the FFmpeg build step for Windows in the scheduled workflow.

### Motivation and Context
Fix nightly builds.

### How Has This Been Tested?
Needs to be tested on CI itself.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
