### PR TITLE
CI: Add workflow_dispatch trigger to scheduled workflow

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,6 +1,7 @@
 name: Scheduled
 run-name: Scheduled Repository Actions ⏰
 on:
+  workflow_dispatch:
   schedule:
     - cron: 12 0 * * *
 permissions:


### PR DESCRIPTION
### Description
Adds the `workflow_dispatch` trigger to the scheduled workflow to enable manual triggering of it via web interface or API.

### Motivation and Context
Allows re-running failed scheduled runs after the underlying issue has been fixed.

### How Has This Been Tested?
Tested on fork by merging straight to master before.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
