### PR TITLE
CI: Remove superfluous step to publish Windows Qt artifacts

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -375,13 +375,6 @@ jobs:
           target: ${{ matrix.target }}
           config: ${{ matrix.config }}
 
-      - name: Publish Build Artifacts
-        if: matrix.target == 'x64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.artifactName }}
-          path: ${{ github.workspace }}/windows/${{ steps.setup.outputs.artifactFileName }}
-
   windows-qt6-arm64-build:
     name: Build Qt6 (Windows ARM64)
     runs-on: windows-2022


### PR DESCRIPTION
### Description
Removes the publish step from the Windows Qt6 build job.

### Motivation and Context
Publish step was not intended to be contained in the build job and is a left-over from when the job was copied over from the main workflow.

### How Has This Been Tested?
Will need testing on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
