### PR TITLE
deps.windows: Fix architecture mismatch when building on ARM64 host

### DIFF
--- a/deps.windows/40-detours.ps1
+++ b/deps.windows/40-detours.ps1
@@ -40,7 +40,7 @@ function Build {
         Target = $Target
     }
 
-    if ( $Target -eq 'x86' ) {
+    if ( $env:CI -ne $null -and $Target -eq 'x86' ) {
         $Params += @{
             HostArchitecture = $Target
         }

--- a/utils.pwsh/Setup-Host.ps1
+++ b/utils.pwsh/Setup-Host.ps1
@@ -35,11 +35,4 @@ function Cleanup {
     Log-Debug "Running Cleanup actions"
 }
 
-function Get-HostArchitecture {
-    $Host64Bit = [System.Environment]::Is64BitOperatingSystem
-    $HostArchitecture = ('x86', 'x64')[$Host64Bit]
-
-    return $HostArchitecture
-}
-
-$script:HostArchitecture = Get-HostArchitecture
+$script:HostArchitecture = ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture).ToString().ToLower()


### PR DESCRIPTION
### Description
Changes the DevShell arguments to explicitly include the host architecture whenever the `x86` architecture needs to be built on GitHub Actions runners.

### Motivation and Context
While working without issue on local machines, it seems to be that the build scripts cannot correctly invoke a DevShell and the detours `nmake` build system for the x86 architecture without explicitly specifying the host architecture.

The same workaround breaks building other architecture on actual ARM64 Windows machines, thus it is now limited to CI runs only.

### How Has This Been Tested?
Tested locally in a Windows ARM64 VM, will be tested by CI for other architectures.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
