### PR TITLE
Some ARM64 on Windows work

### DIFF
--- a/.Wingetfile
+++ b/.Wingetfile
@@ -1,4 +1,4 @@
 package '7zip.7zip', path: '7-zip', bin: '7z'
 package 'cmake', path: 'Cmake\bin', bin: 'cmake'
 package 'MSYS2.MSYS2', path: 'C:\msys64\usr\bin', bin 'bash'
-package 'meson', path: 'Meson', bin 'meson'
+package 'mesonbuild.meson', path: 'Meson', bin 'meson'

--- a/deps.ffmpeg/80-amf.ps1
+++ b/deps.ffmpeg/80-amf.ps1
@@ -3,7 +3,7 @@ param(
     [string] $Version = '1.4.36',
     [string] $Uri = 'https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git',
     [string] $Hash = '8f5a645e89380549368eec68935b151b238aa17b',
-    [array] $Targets = @('x64')
+    [array] $Targets = @('x64', 'arm64')
 )
 
 function Setup {

--- a/deps.qt/patches/Qt6/arm64/0001-override-host-req.patch
+++ b/deps.qt/patches/Qt6/arm64/0001-override-host-req.patch
@@ -1,0 +1,17 @@
+--- a/qtbase/cmake/QtPublicDependencyHelpers.cmake
++++ b/qtbase/cmake/QtPublicDependencyHelpers.cmake
+@@ -212,7 +212,13 @@ function(_qt_internal_determine_if_host_info_package_needed out_var)
+ endfunction()
+ 
+ macro(_qt_internal_find_host_info_package platform_requires_host_info)
+-    if(${platform_requires_host_info})
++    if(DEFINED QT_REQUIRE_HOST_PATH_CHECK)
++        set(_qt_platform_requires_host_info "${QT_REQUIRE_HOST_PATH_CHECK}")
++    else()
++        set(_qt_platform_requires_host_info "${platform_requires_host_info}")
++    endif()
++
++    if(_qt_platform_requires_host_info)
+         find_package(Qt6HostInfo
+                      CONFIG
+                      REQUIRED

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -3,6 +3,12 @@ param(
     [string] $Version = '6.6.3',
     [string] $Uri = 'https://download.qt.io/archive/qt/6.6/6.6.3',
     [string] $Hash = "${PSScriptRoot}/checksums",
+    [array] $Patches = @(
+        @{
+            PatchFile = "${PSScriptRoot}/patches/qt6/arm64/0001-override-host-req.patch"
+            HashSum = "B13A06D681046DC514BF3BD6686C9FB0AB47A670445690546B0E5B513117565E"
+        }
+    ),
     [array] $Targets = @('x64', 'arm64')
 )
 


### PR DESCRIPTION
### Description
With existing qt6 deps you will get following while trying to build obs-studio on Windows ARM64 host machine. Note, I get some other "host" related issues when building on x64 so perhaps the changes proposed here are moot as obs-studio ARM64 bits will likely get built on x64 host machines. For example, I get swig.exe issues with obs-deps-2025-02-04-arm64/bin/swig.exe during find_package call as it's using the arm64 bits on an x64 host. So in other words, there are larger issues at hand with using the arm64 deps where we need to package up x64 bits side by side.  In any case, here's proposal:

Here is the error you'll get with today's qt6 arm64 deps while trying to build obs-studio.

CMake Error at .deps/obs-deps-qt6-2025-02-04-arm64/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake:258 (message):
  To use a cross-compiled Qt, please set the QT_HOST_PATH cache variable to
  the location of your host Qt installation.
Call Stack (most recent call first):
  .deps/obs-deps-qt6-2025-02-04-arm64/lib/cmake/Qt6/Qt6Dependencies.cmake:7 (_qt_internal_setup_qt_host_path)
  .deps/obs-deps-qt6-2025-02-04-arm64/lib/cmake/Qt6/Qt6Config.cmake:119 (include)
  libobs/CMakeLists.txt:18 (find_package)

You can fix this issue if you set QT_REQUIRE_HOST_PATH_CHECK to false.  However, you'll then end up with following:

CMake Error at .deps/obs-deps-qt6-2025-02-04-arm64/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake:216 (find_package):
  Could not find a package configuration file provided by "Qt6HostInfo" with
  any of the following names:

    Qt6HostInfoConfig.cmake
    qt6hostinfo-config.cmake

  Add the installation prefix of "Qt6HostInfo" to CMAKE_PREFIX_PATH or set
  "Qt6HostInfo_DIR" to a directory containing one of the above files.  If
  "Qt6HostInfo" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  .deps/obs-deps-qt6-2025-02-04-arm64/lib/cmake/Qt6/Qt6Dependencies.cmake:11 (_qt_internal_find_host_info_package)
  .deps/obs-deps-qt6-2025-02-04-arm64/lib/cmake/Qt6/Qt6Config.cmake:119 (include)
  libobs/CMakeLists.txt:18 (find_package)

I think the reason this is happening is how the QT6 arm64 deps are getting created. They get built on an x64 (I assume) and furthermore the CI environment I bet is also x64 (further assuming). When building ARM64 QT bits on an x64 system you'll end up with following error:

"This version of <retracted>\obs-deps\windows_build_temp\qt6\qtbase\build_arm64\bin\syncqt.exe is not compatible with the version of Windows you're running. Check your computer's system information and then contact the software publisher."

The workaround for this error seems to be to set the QtHostPath env var to point to the just built x64 bits of QT6. This then confuses the obs-studio cmake environment per above when the arm64 bits are packaged up and dropped into obs-studio environment. 

So to fix this, I'm proposing to patch qt6 cmake file to add another check for QT_REQUIRE_HOST_PATH_CHECK. I don't like having to patch as when we move forward to newer qt6 versions this will likely be flaky. Would be nice to just get this added to qt6 as well? 

Or, is there a better way to avoid the above?

Other fixes:
- meson wasn't getting found with winget for me, had to specify mesonbuild.meson
- I didn't fix this, by MSYS2.MSYS2 isn't happy on ARM64 Windows, I need to manually install with the arm64 .sfx.exe of MSYS2 and move it to C:\msys2, future fix perhaps (check for building on arm64 and use the .sfx.exe?)
- Added ffmpeg/amf to the arm64 list?  Seemed like low hanging fruit to keep obs-studio happy.  Without it you'll get following:

CMake Warning (dev) at cmake/finders/FindAMF.cmake:56 (message):
  Failed to find AMF version.
Call Stack (most recent call first):
  plugins/obs-ffmpeg/cmake/dependencies.cmake:16 (find_package)
  plugins/obs-ffmpeg/CMakeLists.txt:10 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

### Motivation and Context
Move native Windows on ARM64 obs-studio creation further forward.

### How Has This Been Tested?
Built obs-studio on a Windows ARM64 laptop using private deps generated by proposed change.

### Types of changes
Tweak (non-breaking change to improve existing functionality) 

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
