### PR TITLE
deps.ffmpeg: Enable PDBs for FFmpeg builds on Windows

### DIFF
--- a/Build-Dependencies.ps1
+++ b/Build-Dependencies.ps1
@@ -122,7 +122,7 @@ function Package-Dependencies {
 
     switch ( $PackageName ) {
         ffmpeg {
-            Get-ChildItem ./bin/* -Include '*.exe','srt-ffplay' -Exclude 'ffmpeg.exe','ffprobe.exe' | Remove-Item -Force -Recurse
+            Get-ChildItem ./bin/* -Include '*.exe','srt-ffplay' -Exclude 'ffmpeg.exe','ffprobe.exe','ffmpeg_g.exe','ffprobe_g.exe' | Remove-Item -Force -Recurse
             Get-ChildItem ./lib -Exclude 'librist.lib','zlibstatic.lib','srt.lib','libx264.lib','mbed*.lib','everest.lib','p256m.lib','zlib.lib','datachannel.lib','cmake' | Remove-Item -Force -Recurse
             Get-ChildItem ./lib/cmake -Exclude 'LibDataChannel','MbedTLS' | Remove-Item -Force -Recurse
             Get-ChildItem ./share/* | Remove-Item -Force -Recurse

--- a/deps.ffmpeg/99-ffmpeg.ps1
+++ b/deps.ffmpeg/99-ffmpeg.ps1
@@ -68,7 +68,8 @@ function Configure {
         '--toolchain=msvc'
         ('--extra-cflags=' + "'-D_WINDLL -MD -D_WIN32_WINNT=0x0A00" + $(if ( $Target -eq 'arm64' ) { ' -D__ARM_PCS_VFP' }) + "'")
         ('--extra-cxxflags=' + "'-MD -D_WIN32_WINNT=0x0A00'")
-        ('--extra-ldflags=' + "'-APPCONTAINER:NO -MACHINE:${Target}'")
+        ('--extra-ldflags=' + "'-APPCONTAINER:NO -MACHINE:${Target} -DEBUG" +
+            $(if ( $Configuration -match '(Release|RelWithDebInfo|MinSizeRel)' ) { ' -OPT:REF -OPT:ICF -LTCG -INCREMENTAL:NO' }) + "'")
         $(if ( $Target -eq 'arm64' ) { '--as=armasm64.exe','--cpu=armv8' })
         '--pkg-config=pkg-config'
         $(if ( $Target -ne 'x86' ) { '--target-os=win64' } else { '--target-os=win32' })

--- a/deps.ffmpeg/99-ffmpeg.ps1
+++ b/deps.ffmpeg/99-ffmpeg.ps1
@@ -166,4 +166,9 @@ function Install {
     $env:VERBOSE = $(if ( $VerbosePreference -eq 'Continue' ) { '1' })
     Invoke-DevShell @Params
     $Backup.GetEnumerator() | ForEach-Object { Set-Item -Path "env:\$($_.Key)" -Value $_.Value }
+
+    Push-Location "build_${Target}"
+    Copy-Item 'ffmpeg_g.exe','ffprobe_g.exe' "$($script:ConfigData.OutputPath)/bin"
+    Get-ChildItem -Path '.' -Filter '*.pdb' -Recurse | Copy-Item -Destination "$($script:ConfigData.OutputPath)/bin"
+    Pop-Location
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Enable PDBs for FFmpeg builds on Windows if the Configuration is set to Debug or RelWithDebInfo.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Having PDBs for FFmpeg can be useful for debugging crashes. This was one of the original goals of moving the FFmpeg builds to be natively compiled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally about a year ago. Should probably be retested.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
