### PR TITLE
winget: Fix winget meson installation

### DIFF
--- a/.Wingetfile
+++ b/.Wingetfile
@@ -1,4 +1,4 @@
 package '7zip.7zip', path: '7-zip', bin: '7z'
 package 'cmake', path: 'Cmake\bin', bin: 'cmake'
-package 'MSYS2.MSYS2', path: 'C:\msys64\usr\bin', bin 'bash'
-package 'mesonbuild.meson', path: 'Meson', bin 'meson'
+package 'MSYS2.MSYS2', path: 'C:\msys64\usr\bin', bin: 'bash'
+package 'mesonbuild.meson', path: 'Meson', bin: 'meson'

--- a/.Wingetfile
+++ b/.Wingetfile
@@ -1,4 +1,4 @@
 package '7zip.7zip', path: '7-zip', bin: '7z'
 package 'cmake', path: 'Cmake\bin', bin: 'cmake'
 package 'MSYS2.MSYS2', path: 'C:\msys64\usr\bin', bin 'bash'
-package 'meson', path: 'Meson', bin 'meson'
+package 'mesonbuild.meson', path: 'Meson', bin 'meson'

--- a/utils.pwsh/Install-BuildDependencies.ps1
+++ b/utils.pwsh/Install-BuildDependencies.ps1
@@ -72,7 +72,7 @@ function Install-BuildDependencies {
 
                     Invoke-External winget @Params
                 } else {
-                    if ( $Package -eq 'meson' ) {
+                    if ( $Package -eq 'mesonbuild.meson' ) {
                         python3 -m pip install meson
                     }
                 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix winget meson installation. Without this change, meson will not be installed automatically via winget. Can change the first commit prefix to `utils.pwsh` if preferred, since it also modifies a file there.

A second commit changes the syntax for `.Wingetfile` so that it is uniform for all entries.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Pointed out on #277. Further investigation showed that this does indeed fail if meson cannot be found with `Get-Command`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
