### PR TITLE
deps.qt: Enable creation of dSYM files for all configurations

### DIFF
--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -103,7 +103,7 @@ config() {
     fi
   }
 
-  if (( shared_libs )) && [[ ${config} == Release ]] common_cmake_flags+=(-DFEATURE_separate_debug_info:BOOL=ON -DQT_FEATURE_force_debug_info:BOOL=ON)
+  if (( shared_libs )) && [[ ${config} == Release ]] common_cmake_flags+=(-DQT_FEATURE_force_debug_info:BOOL=ON)
   if (( shared_libs )) && [[ ${config} == Debug ]] common_cmake_flags+=(-DCMAKE_PLATFORM_NO_VERSIONED_SONAME:BOOL=ON)
 
   args=(
@@ -120,6 +120,7 @@ config() {
     -DFEATURE_png:BOOL=ON
     -DFEATURE_printsupport:BOOL=OFF
     -DFEATURE_qmake:BOOL=OFF
+    -DFEATURE_separate_debug_info:BOOL=ON
     -DFEATURE_sql:BOOL=OFF
     -DFEATURE_system_doubleconversion:BOOL=OFF
     -DFEATURE_system_jpeg:BOOL=OFF


### PR DESCRIPTION
### Description
Enable creation of separate debug information for all CMake configurations.

### Motivation and Context
On macOS debug information is kept in the object files generated by the compiler and extracted into dSYM files using the reference information kept in the binaries.

Any binary built in debug information will not contain any debug information, instead the toolchain will find the information in the object files locally. Thus binaries created in debug configuration need to be shipped with their associated dSYM files if they are to be used on a different machine.

### How Has This Been Tested?
Tested with a Qt build with debug configuration, used on a separate computer and confirmed that debug information was correctly found when the associated dSYM files were loaded.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
