### PR TITLE
Add qtserialport to obs-deps

### DIFF
--- a/deps.qt/checksums/qtserialport-everywhere-src-6.8.2.tar.xz.sha256
+++ b/deps.qt/checksums/qtserialport-everywhere-src-6.8.2.tar.xz.sha256
@@ -1,0 +1,1 @@
+ed17e02361e989f149f58d021ab8cd66f21db4cdfb8cde0a462017e6ac1e3be7  qtserialport-everywhere-src-6.8.2.tar.xz

--- a/deps.qt/checksums/qtserialport-everywhere-src-6.8.2.zip.sha256
+++ b/deps.qt/checksums/qtserialport-everywhere-src-6.8.2.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">BA061FC930D8DCEB9691C3273EA0FDDD6E1013409E7DD627F319B594D4EDDC2C</S>
+      <S N="Path">qtserialport-everywhere-src-6.8.2.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -11,6 +11,7 @@ $QtComponents = @(
     'qtimageformats'
     'qtshadertools'
     'qtmultimedia'
+    'qtserialport'
     'qtsvg'
     'qttools'
 )

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -15,6 +15,7 @@ local -a qt_components=(
   'qtimageformats'
   'qtshadertools'
   'qtmultimedia'
+  'qtserialport'
   'qtsvg'
   'qttools'
 )


### PR DESCRIPTION
This is a request to add another Qt component to obs-deps

The obs-ptz plugin uses qtserialport to communicate with remote PTZ cameras. Unfortunatly, it does not seem possible to build QSerialPort outside of the Qt6 library build environment because it links into private Qt interfaces. The plugin used to maintain a private fork of obs-deps just to add qtserialport, but that approach proved to be fragile. Some users have had success putting a copy of qtserialport from the official Qt binaries into the plugins directory, but again it is easy to get out of sync.

Adding qtserialport to the list of Qt modules built in obs-deps solves the problem with low complexity. The library is an official Qt component, is small, and doesn't pull in any additional dependencies.

@PatTheMav you may remember, I made the same request a couple of years ago. At the time you weren't keen to add to components due to long github action build times. Instead I tried maintaining a fork of obs-deps, but that was quite fragile as described above. The plugin became very hard to up rev and is broken since the 29.0 release.

I did some build time comparisons. Here are two builds, the first is a mainline commit, and the second is after adding qtserialport.

https://github.com/obsproject/obs-deps/actions/runs/14585093923/usage
https://github.com/glikely/obs-deps/actions/runs/14631880990/usage
Wall clock time: 1h 8m 09s   vs.  1h 8m 28s.  delta 19s
Usage time: 4h 18m 46s.  vs.   4h 21m 33s. delta 2m 47s

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [n/a] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
