### PR TITLE
deps.ffmpeg: Update to full AMF 1.4.36

### DIFF
--- a/deps.ffmpeg/80-amf.ps1
+++ b/deps.ffmpeg/80-amf.ps1
@@ -2,7 +2,7 @@ param(
     [string] $Name = 'amf',
     [string] $Version = '1.4.36',
     [string] $Uri = 'https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git',
-    [string] $Hash = '8f5a645e89380549368eec68935b151b238aa17b',
+    [string] $Hash = '16f7d73e0b45c473e903e46981ed0b91efc4c091',
     [array] $Targets = @('x64')
 )
 

--- a/deps.ffmpeg/80-amf.zsh
+++ b/deps.ffmpeg/80-amf.zsh
@@ -4,7 +4,7 @@ autoload -Uz log_debug log_error log_info log_status log_output dep_checkout
 local name='amf'
 local version='1.4.36'
 local url='https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git'
-local hash='8f5a645e89380549368eec68935b151b238aa17b'
+local hash='16f7d73e0b45c473e903e46981ed0b91efc4c091'
 
 ## Dependency Overrides
 local targets=('windows-x*')


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Update to full AMF 1.4.36
- This obs-deps PR is needed for: https://github.com/obsproject/obs-studio/pull/12098

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- This AMF release contains the API for CQP support for B-frame AV1 encoding with AMD cards

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Tested on Navi31

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
