### PR TITLE
Update librist to commit 186bedbb6a2ec77f994689ccdde4a9bd88548d22

### DIFF
--- a/deps.ffmpeg/70-librist.ps1
+++ b/deps.ffmpeg/70-librist.ps1
@@ -2,7 +2,7 @@ param(
     [string] $Name = 'librist',
     [string] $Version = '0.2.7',
     [string] $Uri = 'https://code.videolan.org/rist/librist.git',
-    [string] $Hash = "809390b3b75a259a704079d0fb4d8f1b5f7fa956",
+    [string] $Hash = "186bedbb6a2ec77f994689ccdde4a9bd88548d22",
     [array] $Targets = @('x64', 'arm64'),
     [array] $Patches = @(
         @{

--- a/deps.ffmpeg/70-librist.zsh
+++ b/deps.ffmpeg/70-librist.zsh
@@ -4,7 +4,7 @@ autoload -Uz log_debug log_error log_info log_status log_output
 local name='librist'
 local version='0.2.7'
 local url='https://code.videolan.org/rist/librist.git'
-local hash='809390b3b75a259a704079d0fb4d8f1b5f7fa956'
+local hash='186bedbb6a2ec77f994689ccdde4a9bd88548d22'
 local -a patches=(
   "macos ${0:a:h}/patches/librist/0001-generate-cross-compile-files-macos.patch \
     e14ae6f6565c9412c3f99f3917c1e8410181faede1530cbc014d2d5e03f9c124"


### PR DESCRIPTION
### Description
Updated the dependency scripts `deps.ffmpeg/70-librist.zsh` and `deps.ffmpeg/70-librist.ps1` to reflect the latest commit hash of `librist`.

This ensures OBS builds with the most recent version of `librist`, which includes important bug fixes and improvements.

### Motivation and Context
The previously used version of `librist` was outdated and caused runtime crashes (confirmed with some versions >= 0.2.9).  
This update points to a commit where those issues have been resolved.

See:  
https://code.videolan.org/rist/librist/-/commit/<commit_id>

### How Has This Been Tested?
- Successfully rebuilt FFmpeg with the updated `librist` hash on macOS Sequoia (ARM64).
- Rebuilt OBS with the updated FFmpeg.
- Tested RIST output in OBS; confirmed that the previous crash no longer occurs.
- No regressions or side effects observed in other features.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup (non-breaking change that updates a dependency)
- [ ] Documentation (non-user-facing update to scripts)

### Checklist:
- [x] My code has been run through `clang-format`
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
