### PR TITLE
Build Qt6 natively on Windows on Arm

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -566,63 +566,6 @@ jobs:
           config: ${{ matrix.config }}
 
       - name: Publish Build Artifacts
-        if: matrix.target == 'x64' || (github.event_name != 'pull_request' || fromJSON(needs.pre-checks.outputs.seekingTesters))
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.artifactName }}
-          path: ${{ github.workspace }}/windows/${{ steps.setup.outputs.artifactFileName }}
-
-  windows-qt6-arm64-build:
-    name: Build Qt6 (Windows ARM64)
-    runs-on: windows-2022
-    needs: [pre-checks, windows-qt6-build]
-    strategy:
-      fail-fast: true
-      matrix:
-        config: [RelWithDebInfo, Debug]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        id: setup
-        run: |
-          # Setup Environment
-          $HostArtifactName="qt6-windows-x64-${{ matrix.config }}-${{ needs.pre-checks.outputs.shortHash }}"
-          $HostFileName="windows-deps-qt6-$(Get-Date -Format 'yyyy-MM-dd')-x64-${{ matrix.config }}.zip"
-
-          $ArtifactName="qt6-windows-arm64-${{ matrix.config }}-${{ needs.pre-checks.outputs.shortHash }}"
-          $FileName="windows-deps-qt6-$(Get-Date -Format 'yyyy-MM-dd')-arm64-${{ matrix.config }}.zip"
-
-          "hostArtifactName=${HostArtifactName}" >> $env:GITHUB_OUTPUT
-          "hostArtifactFileName=${HostFileName}" >> $env:GITHUB_OUTPUT
-          "qtHostPath=${env:GITHUB_WORKSPACE}/Qt6Host" >> $env:GITHUB_OUTPUT
-          "artifactName=${ArtifactName}" >> $env:GITHUB_OUTPUT
-          "artifactFileName=${FileName}" >> $env:GITHUB_OUTPUT
-
-      - name: Download Host Tools Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.hostArtifactName }}
-          path: ${{ github.workspace }}/Qt6Host
-
-      - name: Setup Host Tools Artifact
-        run: |
-          . ${{ github.workspace }}/utils.pwsh/Expand-ArchiveExt
-
-          Set-Location ${{ github.workspace }}/Qt6Host
-          Expand-ArchiveExt -Path ${{ steps.setup.outputs.hostArtifactFileName }} -DestinationPath (Get-Location | Convert-Path)
-
-      - name: Build Windows Qt
-        uses: ./.github/actions/build-qt
-        env:
-          QtHostPath: ${{ steps.setup.outputs.qtHostPath }}
-        with:
-          target: arm64
-          config: ${{ matrix.config }}
-
-      - name: Publish Build Artifacts
         if: github.event_name != 'pull_request' || fromJSON(needs.pre-checks.outputs.seekingTesters)
         uses: actions/upload-artifact@v4
         with:
@@ -636,7 +579,7 @@ jobs:
       fail-fast: true
       matrix:
         target: [x64, arm64]
-    needs: [pre-checks, windows-qt6-build, windows-qt6-arm64-build]
+    needs: [pre-checks, windows-qt6-build]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -537,13 +537,18 @@ jobs:
 
   windows-qt6-build:
     name: Build Qt6 (Windows)
-    runs-on: windows-2022
     needs: pre-checks
     strategy:
       fail-fast: true
       matrix:
-        target: [x64]
+        target: [x64, arm64]
         config: [RelWithDebInfo, Debug]
+        include:
+          - target: x64
+            runner-os: windows-2022
+          - target: arm64
+            runner-os: windows-11-arm
+    runs-on: ${{ matrix.runner-os }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Use GitHub Actions matrix and include features to build Qt6 natively on Windows on Arm instead of first building the host tools on x64.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Building Qt6 this way allows us to build the Windows x64 and arm64 variants in parallel instead of in sequence, saving approximately 30 minutes of CI time on a fresh build.

Opening this PR to show that this can be done and so work is not repeated.

Right now it is in Public Preview with no published ETA for GA. I would prefer not to merge this until the WoA image is GA unless we determine that the benefits are more immediately desired.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested as WIP commits on my fork's master branch to show that it will build. I have not yet built a Windows arm64 version of OBS Studio against the resulting artifacts.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- CI

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
