### PR TITLE
deps.ffmpeg: Update mbedTLS to 3.6.4

### DIFF
--- a/deps.ffmpeg/60-mbedtls.ps1
+++ b/deps.ffmpeg/60-mbedtls.ps1
@@ -1,8 +1,8 @@
 param(
     [string] $Name = 'mbedtls',
-    [string] $Version = '3.6.2',
+    [string] $Version = '3.6.4',
     [string] $Uri = 'https://github.com/Mbed-TLS/mbedtls.git',
-    [string] $Hash = '107ea89daaefb9867ea9121002fbbdf926780e98',
+    [string] $Hash = 'c765c831e5c2a0971410692f92f7a81d6ec65ec2',
     [array] $Targets = @('x64', 'arm64'),
     [array] $Patches = @(
         @{

--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -3,15 +3,15 @@ autoload -Uz log_debug log_error log_info log_status log_output
 ## Dependency Information
 local name='mbedtls'
 local -A versions=(
-  macos 3.6.2
-  linux 3.6.2
-  windows 3.6.2
+  macos 3.6.4
+  linux 3.6.4
+  windows 3.6.4
 )
 local url='https://github.com/Mbed-TLS/mbedtls.git'
 local -A hashes=(
-  macos 107ea89daaefb9867ea9121002fbbdf926780e98
-  linux 107ea89daaefb9867ea9121002fbbdf926780e98
-  windows 107ea89daaefb9867ea9121002fbbdf926780e98
+  macos c765c831e5c2a0971410692f92f7a81d6ec65ec2
+  linux c765c831e5c2a0971410692f92f7a81d6ec65ec2
+  windows c765c831e5c2a0971410692f92f7a81d6ec65ec2
 )
 local -a patches=(
   "macos ${0:a:h}/patches/mbedtls/0001-enable-posix-threading-support.patch \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix an issue where TLS/RTMPS connections would fail.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

In OBS Studio 31.1.0, mbedTLS 3.6.2 causes RTMPS connections to fail. This was noticed by connections to Facebook Live failing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally and this seems to fix streaming to Facebook Live.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
