### PR TITLE
utils.pwsh: Force an update of the msys2 keyring before host update

### DIFF
--- a/utils.pwsh/Setup-Host.ps1
+++ b/utils.pwsh/Setup-Host.ps1
@@ -28,6 +28,7 @@ function Setup-Host {
         }
 
         Install-BuildDependencies -WingetFile ${script:PSScriptRoot}/.Wingetfile
+        Invoke-External bash.exe -c "rm -rf /etc/pacman.d/gnupg; pacman-key --init && pacman-key --populate msys2"
         Invoke-External pacman.exe -S --sysupgrade --refresh --refresh --noconfirm --needed --noprogressbar
     }
 }


### PR DESCRIPTION
### Description
Updates the `msys2-keyring` before doing a full msys2 system update.

### Motivation and Context
If the keyring is too outdated before an update is triggered, it seems that the public keys used to sign the updated packages are not considered valid by the local system and thus the update fails.

This attempts to update the keyring before doing the actual update.

### How Has This Been Tested?
Requires test runs on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
