### PR TITLE
deps.qt: Backport upstream patch removing AGL linkage from macOS

### DIFF
--- a/deps.qt/patches/Qt6/mac/0002-QTBUG-137687.patch
+++ b/deps.qt/patches/Qt6/mac/0002-QTBUG-137687.patch
@@ -1,0 +1,60 @@
+From cdb33c3d5621ce035ad6950c8e2268fe94b73de5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Tue, 10 Jun 2025 06:46:30 -0700
+Subject: [PATCH] macOS: Remove linkage to AGL framework
+
+It's no longer available on macOS 26, and we don't use it anymore
+anyways.
+
+Pick-to: 6.10 6.9 6.8 6.5
+Change-Id: Ia1d0e37dda177f333646e598e517f4af20215dad
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ cmake/FindWrapOpenGL.cmake | 9 ---------
+ mkspecs/common/mac.conf    | 5 ++---
+ 2 files changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/qtbase/cmake/FindWrapOpenGL.cmake b/qtbase/cmake/FindWrapOpenGL.cmake
+index 7295a159caf6..fe73ab782118 100644
+--- a/qtbase/cmake/FindWrapOpenGL.cmake
++++ b/qtbase/cmake/FindWrapOpenGL.cmake
+@@ -37,16 +37,7 @@ if (OpenGL_FOUND)
+             set(__opengl_fw_path "-framework OpenGL")
+         endif()
+
+-        find_library(WrapOpenGL_AGL NAMES AGL)
+-        if(WrapOpenGL_AGL)
+-            set(__opengl_agl_fw_path "${WrapOpenGL_AGL}")
+-        endif()
+-        if(NOT __opengl_agl_fw_path)
+-            set(__opengl_agl_fw_path "-framework AGL")
+-        endif()
+-
+         target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_fw_path})
+-        target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_agl_fw_path})
+     else()
+         target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE OpenGL::GL)
+     endif()
+diff --git a/qtbase/mkspecs/common/mac.conf b/qtbase/mkspecs/common/mac.conf
+index 61bea952b220..9ba38d9949d6 100644
+--- a/qtbase/mkspecs/common/mac.conf
++++ b/qtbase/mkspecs/common/mac.conf
+@@ -18,8 +18,7 @@ QMAKE_LIBDIR            =
+
+ # sdk.prf will prefix the proper SDK sysroot
+ QMAKE_INCDIR_OPENGL     = \
+-    /System/Library/Frameworks/OpenGL.framework/Headers \
+-    /System/Library/Frameworks/AGL.framework/Headers/
++    /System/Library/Frameworks/OpenGL.framework/Headers
+
+ QMAKE_FIX_RPATH         = install_name_tool -id
+
+@@ -30,7 +29,7 @@ QMAKE_LFLAGS_REL_RPATH  =
+ QMAKE_REL_RPATH_BASE    = @loader_path
+
+ QMAKE_LIBS_DYNLOAD      =
+-QMAKE_LIBS_OPENGL       = -framework OpenGL -framework AGL
++QMAKE_LIBS_OPENGL       = -framework OpenGL
+ QMAKE_LIBS_THREAD       =
+
+ QMAKE_INCDIR_WAYLAND    =

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -8,6 +8,8 @@ local hash="${0:a:h}/checksums"
 local -a patches=(
   "macos ${0:a:h}/patches/Qt6/mac/0001-QTBUG-121351.patch \
     df46dc93e874c36b2ad0da746c43585528308a7fcde60930c1ffb5e841472e7b"
+  "macos ${0:a:h}/patches/Qt6/mac/0002-QTBUG-137687.patch \
+    2ddccdaf111332618e8d95ebf483f1f393d499acd5212b74fa497a1c2134b796"
 )
 
 local -a qt_components=(


### PR DESCRIPTION
### Description
Backports the `qtbase` commit removing AGL from the list of linked frameworks when OpenGL is used by Qt.

Original commit: https://codereview.qt-project.org/c/qt/qtbase/+/652022

### Motivation and Context
The AGL framework (the Carbon OpenGL bindings) has been removed in macOS 26. Without this change, it's not possible to build OBS Studio with Xcode 26 and the macOS 26 platform SDK.

### How Has This Been Tested?
Tested on macOS 26 (25A5316i) with Xcode 26 beta 4 (17A5285i). Project configured, built, and ran without issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
