### PR TITLE
utils.pwsh: Remove manual pacman keyring upgrade

### DIFF
--- a/utils.pwsh/Setup-Host.ps1
+++ b/utils.pwsh/Setup-Host.ps1
@@ -28,8 +28,6 @@ function Setup-Host {
         }
 
         Install-BuildDependencies -WingetFile ${script:PSScriptRoot}/.Wingetfile
-        Invoke-External bash.exe -c "rm -rf /etc/pacman.d/gnupg; pacman-key --init && pacman-key --populate msys2"
-        Invoke-External pacman.exe -S --sysupgrade --refresh --refresh --noconfirm --needed --noprogressbar
     }
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Remove the manual pacman keyring upgrade.

Effectively reverts:
* https://github.com/obsproject/obs-deps/pull/294

Partially reverts:
* https://github.com/obsproject/obs-deps/pull/292

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The Windows 11 Arm runners do not have MSYS2 installed, and attempts to manually install it have failed. Installing via winget fails because winget is not available on the windows-2022 or windows-11-arm runners. Installing via chocolately fails because its install destination is non-standard, and their option to change the install destination is a paid option.

Just remove the manual pacman keyring upgrade for now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on my fork:
* https://github.com/RytoEX/obs-deps/actions/runs/17163679508/attempts/1
* https://github.com/RytoEX/obs-deps/actions/runs/17163679508

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
