### PR TITLE
Add Steinberg VST3 SDK

### DIFF
--- a/deps.macos/90-vst3.zsh
+++ b/deps.macos/90-vst3.zsh
@@ -1,0 +1,33 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='vst3sdk'
+local version='3.8.0'
+local url='https://github.com/steinbergmedia/vst3sdk.git'
+local hash="9fad9770f2ae8542ab1a548a68c1ad1ac690abe0"
+
+## Build Steps
+setup() {
+  log_info "Setup (%F{3}${target}%f)"
+  setup_dep ${url} ${hash}
+}
+
+install() {
+  log_info "Install (%F{3}${target}%f)"
+  cd ${dir}
+
+  mkdir -p \
+    ${target_config[output_dir]}/include \
+    ${target_config[output_dir]}/licenses/vst3sdk
+
+  mkdir -p ${target_config[output_dir]}/include/vst3sdk
+  cp -R base ${target_config[output_dir]}/include/vst3sdk/
+  cp -R pluginterfaces "${target_config[output_dir]}/include/vst3sdk/"
+
+  mkdir -p ${target_config[output_dir]}/include/vst3sdk/public.sdk
+  cp -R public.sdk/source ${target_config[output_dir]}/include/vst3sdk/public.sdk/
+
+  if [[ -f "LICENSE.txt" ]]; then
+    cp LICENSE.txt ${target_config[output_dir]}/licenses/vst3sdk/
+  fi
+}

--- a/deps.windows/90-vst3.ps1
+++ b/deps.windows/90-vst3.ps1
@@ -1,0 +1,61 @@
+param(
+    [string] $Name = 'vst3sdk',
+    [string] $Version = 'v3.8.0',
+    [string] $Uri = 'https://github.com/steinbergmedia/vst3sdk.git',
+    [string] $Hash = '9fad9770f2ae8542ab1a548a68c1ad1ac690abe0',
+    [array] $Targets = @('x64', 'arm64')
+)
+
+function Setup {
+    Log-Information "Setup (${Target})"
+    Setup-Dependency -Uri $Uri -Hash $Hash -DestinationPath $Path
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Params = @{
+        ErrorAction = "SilentlyContinue"
+        Path        = @(
+            "$($ConfigData.OutputPath)/include",
+            "$($ConfigData.OutputPath)/licenses"
+        )
+        ItemType    = "Directory"
+        Force       = $true
+    }
+    New-Item @Params *> $null
+
+    $Items = @(
+        @{
+            Path        = "base"
+            Destination = "$($ConfigData.OutputPath)/include/vst3sdk/base"
+            Recurse     = $true
+            ErrorAction = 'SilentlyContinue'
+        }
+        @{
+            Path        = "pluginterfaces"
+            Destination = "$($ConfigData.OutputPath)/include/vst3sdk/pluginterfaces"
+            Recurse     = $true
+            ErrorAction = 'SilentlyContinue'
+        }
+        @{
+            Path        = "public.sdk/source"
+            Destination = "$($ConfigData.OutputPath)/include/vst3sdk/public.sdk/source"
+            Recurse     = $true
+            ErrorAction = 'SilentlyContinue'
+        }
+        @{
+            Path        = "LICENSE.txt"
+            Destination = "$($ConfigData.OutputPath)/licenses/vst3sdk"
+            Force       = $true
+            ErrorAction = 'SilentlyContinue'
+        }
+    )
+
+    $Items | ForEach-Object {
+        $Item = $_
+        Log-Output ('{0} => {1}' -f ($Item.Path -join ", "), $Item.Destination)
+        Copy-Item @Item
+    }
+}


### PR DESCRIPTION
### Description
This adds Steinberg VST3 SDK to obs-deps in the include subfolder of the zips.

### Motivation and Context
Allows building of obs-vst3, cf : https://github.com/obsproject/obs-studio/pull/12752

### How Has This Been Tested?
Tested on my fork; successfully adds the SDK and allows building of obs-vst3 on windows and macOS.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
