### PR TITLE
deps.ffmpeg: Update libdatachannel to v0.24.2

### DIFF
--- a/deps.ffmpeg/70-libdatachannel.ps1
+++ b/deps.ffmpeg/70-libdatachannel.ps1
@@ -1,8 +1,8 @@
 param(
     [string] $Name = 'libdatachannel',
-    [string] $Version = 'v0.21.0',
+    [string] $Version = 'v0.24.2',
     [string] $Uri = 'https://github.com/paullouisageneau/libdatachannel.git',
-    [string] $Hash = '9d5c46b8f506943727104d766e5dad0693c5a223',
+    [string] $Hash = '4e4f4892dccb2a57fe3a490d0c9d958de4244e74',
     [array] $Targets = @('x64', 'arm64'),
     [switch] $ForceShared = $true
 )

--- a/deps.ffmpeg/70-libdatachannel.zsh
+++ b/deps.ffmpeg/70-libdatachannel.zsh
@@ -2,9 +2,9 @@ autoload -Uz log_debug log_error log_info log_status log_output
 
 ## Dependency Information
 local name='libdatachannel'
-local version='v0.21.0'
+local version='v0.24.2'
 local url='https://github.com/paullouisageneau/libdatachannel.git'
-local hash='9d5c46b8f506943727104d766e5dad0693c5a223'
+local hash='4e4f4892dccb2a57fe3a490d0c9d958de4244e74'
 
 ## Dependency Overrides
 local -i shared_libs=1


### PR DESCRIPTION
### Description
Upgrade to the latest version of libdatachannel

### Motivation and Context
Trying to keep libdatachannel tracking to the latest. Fixes obsproject/obs-studio#10313 and adds ice-tcp support

### How Has This Been Tested?
I have tested on macOS and Linux and Windows (using VMWare Fusion)

### Types of changes

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
