### PR TITLE
utils.pwsh: Fix Windows config paths

### DIFF
--- a/utils.pwsh/Setup-Host.ps1
+++ b/utils.pwsh/Setup-Host.ps1
@@ -20,7 +20,7 @@ function Setup-Host {
         $script:ProjectRoot = $($script:PSScriptRoot)
     }
 
-    $script:WorkRoot = "${ProjectRoot}\windows_build_temp"
+    $script:WorkRoot = "${ProjectRoot}/windows_build_temp"
 
     if ( ! ( $script:SkipAll ) && ( $script:SkipDeps ) ) {
         if ( ! ( Test-Path function:Install-BuildDependencies ) ) {

--- a/utils.pwsh/Setup-Target.ps1
+++ b/utils.pwsh/Setup-Target.ps1
@@ -27,7 +27,7 @@ function Setup-Target {
     $script:ConfigData = $TargetData[$script:Target]
 
     $script:ConfigData += @{
-        OutputPath = "${script:ProjectRoot}\windows\obs-${script:PackageName}-${script:Target}"
+        OutputPath = "${script:ProjectRoot}/windows/obs-${script:PackageName}-${script:Target}"
     }
 
     Log-Debug "


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Apparently, CMake can fail when parsing the current path string because it interprets the backslash as the start of an escape sequence. Modern Windows can interpret paths with forward slashes, so it should be safe to change these slashes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Discovered this while attempting to update dependencies. Want to fix it separate from that update.

https://github.com/RytoEX/obs-deps/actions/runs/23963204885/job/69897580516#step:4:6211

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I haven't tested this change yet, but we use forward slashes in other paths for Windows elsewhere, so this is hopefully fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
