### PR TITLE
utils.zsh: Enable debug symbols for ObjC

### DIFF
--- a/utils.zsh/30-build.zsh
+++ b/utils.zsh/30-build.zsh
@@ -113,6 +113,8 @@ setup_build_parameters() {
         -DCMAKE_C_FLAGS="${c_flags} -std=c17"
         -DCMAKE_C_FLAGS_RELEASE="-O3 -g -DNDEBUG"
         -DCMAKE_CXX_FLAGS_RELEASE="-O3 -g -DNDEBUG"
+        -DCMAKE_OBJC_FLAGS_RELEASE="-O3 -g -DNDEBUG"
+        -DCMAKE_OBJCXX_FLAGS_RELEASE="-O3 -g -DNDEBUG"
       )
 
       if [[ "${PACKAGE_NAME}" != 'qt6' ]] {


### PR DESCRIPTION
### Description
Adds necessary compiler arguments to emit debug symbols in release builds for ObjC and ObjC++.

### Motivation and Context
To force CMake-based projects to emit debug symbols even in release configuration, the `-g` argument needs to be explicitly added to the global `CMAKE_<LANGUAGE>_FLAGS_RELEASE` variable.

This was done for C and C++ already, but not for ObjC and ObjC++ (which are correctly treated as separate languages by CMake). This is required to make Qt plugins like the cocoa platform plugin "debuggable" with dSYM files loaded into a debugger.

### How Has This Been Tested?
Built Qt locally and confirmed that functions called within the Cocoa platform plugin were correctly debuggable with source code available on the local machine.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
